### PR TITLE
initial commit of HH\Lib\Str\Utf8 library

### DIFF
--- a/src/str/encoding.php
+++ b/src/str/encoding.php
@@ -1,0 +1,60 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004_present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Str;
+
+enum Encoding: string {
+  ASCII = 'ASCII';
+  BASE64 = 'BASE64';
+  EUC_CN = 'EUC-CN';
+  EUC_JP = 'EUC-JP';
+  EUC_KR = 'EUC-KR';
+  EUC_TW = 'EUC-TW';
+  HTML_ENTITIES = 'HTML-ENTITIES';
+  ISO_8859_1 = 'ISO-8859-1';
+  ISO_8859_2 = 'ISO-8859-2';
+  ISO_8859_3 = 'ISO-8859-3';
+  ISO_8859_4 = 'ISO-8859-4';
+  ISO_8859_5 = 'ISO-8859-5';
+  ISO_8859_6 = 'ISO-8859-6';
+  ISO_8859_7 = 'ISO-8859-7';
+  ISO_8859_8 = 'ISO-8859-8';
+  ISO_8859_9 = 'ISO-8859-9';
+  ISO_8859_10 = 'ISO-8859-10';
+  ISO_8859_13 = 'ISO-8859-13';
+  ISO_8859_14 = 'ISO-8859-14';
+  ISO_8859_15 = 'ISO-8859-15';
+  ISO_8859_16 = 'ISO-8859-16';
+  ISO_2022_KR = 'ISO-2022-KR';
+  JIS = 'JIS';
+  KOI8_R = 'KOI8-R';
+  KOI8_U = 'KOI8-U';
+  QUOTED_PRINTABLE = 'Quoted-Printable';
+  SJIS = 'SJIS';
+  UCS2 = 'UCS-2';
+  UCS2BE = 'UCS-2BE';
+  UCS2LE = 'UCS-2LE';
+  UCS4 = 'UCS-4';
+  UCS4BE = 'UCS-4BE';
+  UCS4LE = 'UCS-4LE';
+  UTF32 = 'UTF-32';
+  UTF32BE = 'UTF-32BE';
+  UTF32LE = 'UTF-32LE';
+  UTF16 = 'UTF-16';
+  UTF16BE = 'UTF-16BE';
+  UTF16LE = 'UTF-16LE';
+  UTF8 = 'UTF-8';
+  UTF7 = 'UTF-7';
+  UUENCODE = 'UUENCODE';
+  WINDOWS_1251 = 'Windows-1251';
+  WINDOWS_1252 = 'Windows-1252';
+  WINDOWS_1254 = 'Windows-1254';
+}
+

--- a/src/str/encoding.php
+++ b/src/str/encoding.php
@@ -1,6 +1,6 @@
 <?hh // strict
 /*
- *  Copyright (c) 2004_present, Facebook, Inc.
+ *  Copyright (c) 2004-present, Facebook, Inc.
  *  All rights reserved.
  *
  *  This source code is licensed under the MIT license found in the
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Str;
+namespace HH\Lib\Experimental\Str;
 
 enum Encoding: string {
   ASCII = 'ASCII';

--- a/src/str/grapheme/introspect.php
+++ b/src/str/grapheme/introspect.php
@@ -11,6 +11,7 @@
 namespace HH\Lib\Experimental\Str\Grapheme;
 
 use namespace HH\Lib\_Private;
+use namespace HH\Lib\Str;
 
 /**
  * Returns the length of the given string in grapheme units.
@@ -66,34 +67,6 @@ function search(string $haystack, string $needle, int $offset = 0): ?int {
 function search_ci(string $haystack, string $needle, int $offset = 0): ?int {
   $offset = _Private\validate_offset($offset, length($haystack));
   $position = \grapheme_stripos($haystack, $needle, $offset);
-  if ($position === false) {
-    return null;
-  }
-  return $position;
-}
-
-/**
- * Returns the last position of the "needle" string in the "haystack" string,
- * or null if it isn't found.
- *
- * An optional offset determines where in the haystack (from the beginning) the
- * search begins. If the offset is negative, the search will begin that many
- * characters from the end of the string and go backwards. If the offset is
- * out-of-bounds, a ViolationException will be thrown.
- *
- * - To simply check if the haystack contains the needle, see `Str\contains()`.
- * - To get the first position of the needle, see `Str\Grapheme\search()`.
- *
- * Previously known in PHP as `grapheme_strrpos`.
- */
-<<__RxLocal>>
-function search_last(string $haystack, string $needle, int $offset = 0): ?int {
-  $haystack_length = length($haystack);
-  invariant(
-    $offset >= -$haystack_length && $offset <= $haystack_length,
-    'Offset is out-of-bounds.',
-  );
-  $position = \grapheme_strrpos($haystack, $needle, $offset);
   if ($position === false) {
     return null;
   }

--- a/src/str/grapheme/introspect.php
+++ b/src/str/grapheme/introspect.php
@@ -34,7 +34,6 @@ function length(string $string): int {
  *
  * - To simply check if the haystack contains the needle, see `Str\contains()`.
  * - To get the case-insensitive position, see `Str\Grapheme\search_ci()`.
- * - To get the last position of the needle, see `Str\Grapheme\search_last()`.
  *
  * Previously known in PHP as `grapheme_strpos`.
  */
@@ -59,7 +58,6 @@ function search(string $haystack, string $needle, int $offset = 0): ?int {
  *
  * - To simply check if the haystack contains the needle, see `Str\contains_ci()`.
  * - To get the case-sensitive position, see `Str\Grapheme\search()`.
- * - To get the last position of the needle, see `Str\Grapheme\search_last()`.
  *
  * Previously known in PHP as `grapheme_stripos`.
  */
@@ -72,3 +70,4 @@ function search_ci(string $haystack, string $needle, int $offset = 0): ?int {
   }
   return $position;
 }
+

--- a/src/str/grapheme/introspect.php
+++ b/src/str/grapheme/introspect.php
@@ -1,0 +1,101 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\Str\Grapheme;
+
+use namespace HH\Lib\_Private;
+
+/**
+ * Returns the length of the given string in grapheme units.
+ *
+ * Previously known in PHP as `grapheme_strlen`.
+ */
+<<__RxLocal>>
+function length(string $string): int {
+  return \grapheme_strlen($string);
+}
+
+/**
+ * Returns the first position of the "needle" string in the "haystack" string,
+ * or null if it isn't found.
+ *
+ * An optional offset determines where in the haystack the search begins. If the
+ * offset is negative, the search will begin that many characters from the end
+ * of the string. If the offset is out-of-bounds, a ViolationException will be
+ * thrown.
+ *
+ * - To simply check if the haystack contains the needle, see `Str\contains()`.
+ * - To get the case-insensitive position, see `Str\Grapheme\search_ci()`.
+ * - To get the last position of the needle, see `Str\Grapheme\search_last()`.
+ *
+ * Previously known in PHP as `grapheme_strpos`.
+ */
+<<__RxLocal>>
+function search(string $haystack, string $needle, int $offset = 0): ?int {
+  $offset = _Private\validate_offset($offset, length($haystack));
+  $position = \grapheme_strpos($haystack, $needle, $offset);
+  if ($position === false) {
+    return null;
+  }
+  return $position;
+}
+
+/**
+ * Returns the first position of the "needle" string in the "haystack" string,
+ * or null if it isn't found (case-insensitive).
+ *
+ * An optional offset determines where in the haystack the search begins. If the
+ * offset is negative, the search will begin that many characters from the end
+ * of the string. If the offset is out-of-bounds, a ViolationException will be
+ * thrown.
+ *
+ * - To simply check if the haystack contains the needle, see `Str\contains_ci()`.
+ * - To get the case-sensitive position, see `Str\Grapheme\search()`.
+ * - To get the last position of the needle, see `Str\Grapheme\search_last()`.
+ *
+ * Previously known in PHP as `grapheme_stripos`.
+ */
+<<__RxLocal>>
+function search_ci(string $haystack, string $needle, int $offset = 0): ?int {
+  $offset = _Private\validate_offset($offset, length($haystack));
+  $position = \grapheme_stripos($haystack, $needle, $offset);
+  if ($position === false) {
+    return null;
+  }
+  return $position;
+}
+
+/**
+ * Returns the last position of the "needle" string in the "haystack" string,
+ * or null if it isn't found.
+ *
+ * An optional offset determines where in the haystack (from the beginning) the
+ * search begins. If the offset is negative, the search will begin that many
+ * characters from the end of the string and go backwards. If the offset is
+ * out-of-bounds, a ViolationException will be thrown.
+ *
+ * - To simply check if the haystack contains the needle, see `Str\contains()`.
+ * - To get the first position of the needle, see `Str\Grapheme\search()`.
+ *
+ * Previously known in PHP as `grapheme_strrpos`.
+ */
+<<__RxLocal>>
+function search_last(string $haystack, string $needle, int $offset = 0): ?int {
+  $haystack_length = length($haystack);
+  invariant(
+    $offset >= -$haystack_length && $offset <= $haystack_length,
+    'Offset is out-of-bounds.',
+  );
+  $position = \grapheme_strrpos($haystack, $needle, $offset);
+  if ($position === false) {
+    return null;
+  }
+  return $position;
+}

--- a/src/str/grapheme/select.php
+++ b/src/str/grapheme/select.php
@@ -37,8 +37,8 @@ function slice(string $string, int $offset, ?int $length = null): string {
  * Function to extract a sequence of default grapheme clusters from a text buffer,
  * which must be encoded in UTF-8.
  *
- * The $size determines the number of graphemes to extract, starting at the
- * $start position (in bytes).
+ * `$size` determines the number of graphemes to extract, starting at the
+ * `$start` position (in bytes).
  *
  * Returns a tuple containing the extracted grapheme(s) and the next byte position to use
  * for subsequent calls. If the end of the string is reached, null will be returned.

--- a/src/str/grapheme/select.php
+++ b/src/str/grapheme/select.php
@@ -26,7 +26,11 @@ use namespace HH\Lib\_Private;
 function slice(string $string, int $offset, ?int $length = null): string {
   invariant($length === null || $length >= 0, 'Expected non-negative length.');
   $offset = _Private\validate_offset($offset, length($string));
-  return \grapheme_substr($string, $offset, $length);
+  $result = \grapheme_substr($string, $offset, $length);
+  if ($result === false) {
+    return '';
+  }
+  return $result;
 }
 
 /**
@@ -37,13 +41,22 @@ function slice(string $string, int $offset, ?int $length = null): string {
  * $start position (in bytes).
  *
  * Returns a tuple containing the extracted grapheme(s) and the next byte position to use
- * for subsequent calls.
+ * for subsequent calls. If the end of the string is reached, null will be returned.
  *
  * Previously known in PHP as `grapheme_extract`.
  */
-<<__RxLocal>>
-function extract(string $string, int $size, int $start = null): (string, int) {
+function extract(string $string, int $size, int $start = 0): (?string, int) {
   $next = 0;
-  $result = \grapheme_extract($string, $size, /* $type: count graphemes */ 0, $start, &$next);
+  $result = \grapheme_extract(
+    $string,
+    $size,
+    0, /* $type: count graphemes */
+    $start,
+    &$next,
+  );
+  if ($result === false) {
+    $result = null;
+  }
   return tuple($result, $next);
 }
+

--- a/src/str/grapheme/select.php
+++ b/src/str/grapheme/select.php
@@ -1,0 +1,49 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\Str\Grapheme;
+
+use namespace HH\Lib\_Private;
+
+/**
+ * Returns a substring of length `$length` of the given string starting at the
+ * `$offset`.
+ *
+ * If no length is given, the slice will contain the rest of the
+ * string. If the length is zero, the empty string will be returned. If the
+ * offset is out-of-bounds, a ViolationException will be thrown.
+ *
+ * Previously known in PHP as `grapheme_substr`.
+ */
+<<__RxLocal>>
+function slice(string $string, int $offset, ?int $length = null): string {
+  invariant($length === null || $length >= 0, 'Expected non-negative length.');
+  $offset = _Private\validate_offset($offset, length($string));
+  return \grapheme_substr($string, $offset, $length);
+}
+
+/**
+ * Function to extract a sequence of default grapheme clusters from a text buffer,
+ * which must be encoded in UTF-8.
+ *
+ * The $size determines the number of graphemes to extract, starting at the
+ * $start position (in bytes).
+ *
+ * Returns a tuple containing the extracted grapheme(s) and the next byte position to use
+ * for subsequent calls.
+ *
+ * Previously known in PHP as `grapheme_extract`.
+ */
+<<__RxLocal>>
+function extract(string $string, int $size, int $start = null): (string, int) {
+  $next = 0;
+  $result = \grapheme_extract($string, $size, /* $type: count graphemes */ 0, $start, &$next);
+  return tuple($result, $next);
+}

--- a/src/str/grapheme/select.php
+++ b/src/str/grapheme/select.php
@@ -45,7 +45,7 @@ function slice(string $string, int $offset, ?int $length = null): string {
  *
  * Previously known in PHP as `grapheme_extract`.
  */
-function extract(string $string, int $size, int $start = 0): (?string, int) {
+function extract(string $string, int $size, int $start = 0): ?(string, int) {
   $next = 0;
   $result = \grapheme_extract(
     $string,
@@ -55,7 +55,7 @@ function extract(string $string, int $size, int $start = 0): (?string, int) {
     &$next,
   );
   if ($result === false) {
-    $result = null;
+    return null;
   }
   return tuple($result, $next);
 }

--- a/src/str/utf8/introspect.php
+++ b/src/str/utf8/introspect.php
@@ -107,6 +107,6 @@ function search_last(string $haystack, string $needle, int $offset = 0): ?int {
  */
 <<__RxLocal>>
 function is_utf8(string $string): bool {
-  return \mb_detect_encoding($string, Encoding::UTF8) === Encoding::UTF8;
+  return \mb_check_encoding($string, Encoding::UTF8);
 }
 

--- a/src/str/utf8/introspect.php
+++ b/src/str/utf8/introspect.php
@@ -8,10 +8,10 @@
  *
  */
 
-namespace HH\Lib\Str\Utf8;
+namespace HH\Lib\Experimental\Str\Utf8;
 
 use namespace HH\Lib\_Private;
-use type HH\Lib\Str\Encoding;
+use type HH\Lib\Experimental\Str\Encoding;
 
 /**
  * Returns the length of the given string.
@@ -58,7 +58,7 @@ function search(string $haystack, string $needle, int $offset = 0): ?int {
  * of the string. If the offset is out-of-bounds, a ViolationException will be
  * thrown.
  *
- * - To simply check if the haystack contains the needle, see `Str\contains()`.
+ * - To simply check if the haystack contains the needle, see `Str\contains_ci()`.
  * - To get the case-sensitive position, see `Str\Utf8\search()`.
  * - To get the last position of the needle, see `Str\Utf8\search_last()`.
  *
@@ -106,7 +106,7 @@ function search_last(string $haystack, string $needle, int $offset = 0): ?int {
  * Determine whether a string of unknown encoding is valid UTF-8
  */
 <<__RxLocal>>
-function is_valid(string $string): bool {
+function is_utf8(string $string): bool {
   return \mb_detect_encoding($string, Encoding::UTF8) === Encoding::UTF8;
 }
 

--- a/src/str/utf8/introspect.php
+++ b/src/str/utf8/introspect.php
@@ -1,0 +1,112 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Str\Utf8;
+
+use namespace HH\Lib\_Private;
+use type HH\Lib\Str\Encoding;
+
+/**
+ * Returns the length of the given string.
+ * A multi-byte character is counted as 1.
+ *
+ * Previously known in PHP as `mb_strlen`.
+ */
+<<__RxLocal>>
+function length(string $string): int {
+  return \mb_strlen($string, Encoding::UTF8);
+}
+
+/**
+ * Returns the first position of the "needle" string in the "haystack" string,
+ * or null if it isn't found.
+ *
+ * An optional offset determines where in the haystack the search begins. If the
+ * offset is negative, the search will begin that many characters from the end
+ * of the string. If the offset is out-of-bounds, a ViolationException will be
+ * thrown.
+ *
+ * - To simply check if the haystack contains the needle, see `Str\contains()`.
+ * - To get the case-insensitive position, see `Str\Utf8\search_ci()`.
+ * - To get the last position of the needle, see `Str\Utf8\search_last()`.
+ *
+ * Previously known in PHP as `mb_strpos`.
+ */
+<<__RxLocal>>
+function search(string $haystack, string $needle, int $offset = 0): ?int {
+  $offset = _Private\validate_offset($offset, length($haystack));
+  $position = \mb_strpos($haystack, $needle, $offset, Encoding::UTF8);
+  if ($position === false) {
+    return null;
+  }
+  return $position;
+}
+
+/**
+ * Returns the first position of the "needle" string in the "haystack" string,
+ * or null if it isn't found (case-insensitive).
+ *
+ * An optional offset determines where in the haystack the search begins. If the
+ * offset is negative, the search will begin that many characters from the end
+ * of the string. If the offset is out-of-bounds, a ViolationException will be
+ * thrown.
+ *
+ * - To simply check if the haystack contains the needle, see `Str\contains()`.
+ * - To get the case-sensitive position, see `Str\Utf8\search()`.
+ * - To get the last position of the needle, see `Str\Utf8\search_last()`.
+ *
+ * Previously known in PHP as `mb_stripos`.
+ */
+<<__RxLocal>>
+function search_ci(string $haystack, string $needle, int $offset = 0): ?int {
+  $offset = _Private\validate_offset($offset, length($haystack));
+  $position = \mb_stripos($haystack, $needle, $offset, Encoding::UTF8);
+  if ($position === false) {
+    return null;
+  }
+  return $position;
+}
+
+/**
+ * Returns the last position of the "needle" string in the "haystack" string,
+ * or null if it isn't found.
+ *
+ * An optional offset determines where in the haystack (from the beginning) the
+ * search begins. If the offset is negative, the search will begin that many
+ * characters from the end of the string and go backwards. If the offset is
+ * out-of-bounds, a ViolationException will be thrown.
+ *
+ * - To simply check if the haystack contains the needle, see `Str\contains()`.
+ * - To get the first position of the needle, see `Str\Utf8\search()`.
+ *
+ * Previously known in PHP as `mb_strrpos`.
+ */
+<<__RxLocal>>
+function search_last(string $haystack, string $needle, int $offset = 0): ?int {
+  $haystack_length = length($haystack);
+  invariant(
+    $offset >= -$haystack_length && $offset <= $haystack_length,
+    'Offset is out-of-bounds.',
+  );
+  $position = \mb_strrpos($haystack, $needle, $offset, Encoding::UTF8);
+  if ($position === false) {
+    return null;
+  }
+  return $position;
+}
+
+/**
+ * Determine whether a string of unknown encoding is valid UTF-8
+ */
+<<__RxLocal>>
+function is_valid(string $string): bool {
+  return \mb_detect_encoding($string, Encoding::UTF8) === Encoding::UTF8;
+}
+

--- a/src/str/utf8/select.php
+++ b/src/str/utf8/select.php
@@ -1,0 +1,61 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Str\Utf8;
+
+use namespace HH\Lib\_Private;
+use type HH\Lib\Str\Encoding;
+
+/**
+ * Returns a substring of length `$length` of the given string starting at the
+ * `$offset`.
+ *
+ * If no length is given, the slice will contain the rest of the
+ * string. If the length is zero, the empty string will be returned. If the
+ * offset is out-of-bounds, a ViolationException will be thrown.
+ *
+ * Previously known as `mb_substr` in PHP.
+ */
+<<__RxLocal>>
+function slice(string $string, int $offset, ?int $length = null): string {
+  invariant($length === null || $length >= 0, 'Expected non-negative length.');
+  $offset = _Private\validate_offset($offset, length($string));
+  $result = $length === null
+    ? \mb_substr($string, $offset, Encoding::UTF8)
+    : \mb_substr($string, $offset, $length, Encoding::UTF8);
+  if ($result === false) {
+    return '';
+  }
+  return $result;
+}
+
+/**
+ * Returns a substring of length `$length` of the given string starting at the
+ * `$offset`.
+ *
+ * Operates on bytes instead of characters, unlike Str\Utf8\slice.
+ * If the slice would take place in the middle of a multi-byte character,
+ * the slice is performed starting from the first byte of that character.
+ *
+ * Previously known as `mb_strcut` in PHP.
+ */
+<<__RxLocal>>
+function slice_bytes(string $string, int $offset, ?int $length = null): string {
+  invariant($length === null || $length >= 0, 'Expected non-negative length.');
+  $offset = _Private\validate_offset($offset, length($string));
+  $result = $length === null
+    ? \mb_strcut($string, $offset, Encoding::UTF8)
+    : \mb_strcut($string, $offset, $length, Encoding::UTF8);
+  if ($result === false) {
+    return '';
+  }
+  return $result;
+}
+

--- a/src/str/utf8/select.php
+++ b/src/str/utf8/select.php
@@ -11,6 +11,7 @@
 namespace HH\Lib\Experimental\Str\Utf8;
 
 use namespace HH\Lib\_Private;
+use namespace HH\Lib\Str;
 use type HH\Lib\Experimental\Str\Encoding;
 
 /**
@@ -27,13 +28,7 @@ use type HH\Lib\Experimental\Str\Encoding;
 function slice(string $string, int $offset, ?int $length = null): string {
   invariant($length === null || $length >= 0, 'Expected non-negative length.');
   $offset = _Private\validate_offset($offset, length($string));
-  $result = $length === null
-    ? \mb_substr($string, $offset, Encoding::UTF8)
-    : \mb_substr($string, $offset, $length, Encoding::UTF8);
-  if ($result === false) {
-    return '';
-  }
-  return $result;
+  return \mb_substr($string, $offset, $length, Encoding::UTF8);
 }
 
 /**
@@ -49,13 +44,7 @@ function slice(string $string, int $offset, ?int $length = null): string {
 <<__RxLocal>>
 function slice_bytes(string $string, int $offset, ?int $length = null): string {
   invariant($length === null || $length >= 0, 'Expected non-negative length.');
-  $offset = _Private\validate_offset($offset, length($string));
-  $result = $length === null
-    ? \mb_strcut($string, $offset, Encoding::UTF8)
-    : \mb_strcut($string, $offset, $length, Encoding::UTF8);
-  if ($result === false) {
-    return '';
-  }
-  return $result;
+  $offset = _Private\validate_offset($offset, Str\length($string));
+  return \mb_strcut($string, $offset, $length, Encoding::UTF8);
 }
 

--- a/src/str/utf8/select.php
+++ b/src/str/utf8/select.php
@@ -8,10 +8,10 @@
  *
  */
 
-namespace HH\Lib\Str\Utf8;
+namespace HH\Lib\Experimental\Str\Utf8;
 
 use namespace HH\Lib\_Private;
-use type HH\Lib\Str\Encoding;
+use type HH\Lib\Experimental\Str\Encoding;
 
 /**
  * Returns a substring of length `$length` of the given string starting at the
@@ -21,7 +21,7 @@ use type HH\Lib\Str\Encoding;
  * string. If the length is zero, the empty string will be returned. If the
  * offset is out-of-bounds, a ViolationException will be thrown.
  *
- * Previously known as `mb_substr` in PHP.
+ * Previously known in PHP as `mb_substr`.
  */
 <<__RxLocal>>
 function slice(string $string, int $offset, ?int $length = null): string {
@@ -44,7 +44,7 @@ function slice(string $string, int $offset, ?int $length = null): string {
  * If the slice would take place in the middle of a multi-byte character,
  * the slice is performed starting from the first byte of that character.
  *
- * Previously known as `mb_strcut` in PHP.
+ * Previously known in PHP as `mb_strcut`.
  */
 <<__RxLocal>>
 function slice_bytes(string $string, int $offset, ?int $length = null): string {

--- a/src/str/utf8/transform.php
+++ b/src/str/utf8/transform.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\Experimental\Str\Utf8;
 
-use namespace HH\Lib\_Private;
+use namespace HH\Lib\{_Private, Keyset, Str, Dict};
 use type HH\Lib\Experimental\Str\Encoding;
 
 /**
@@ -45,34 +45,89 @@ function to_encoding(string $string, Encoding $encoding): string {
   return \mb_convert_encoding($string, $encoding, Encoding::UTF8);
 }
 
+type TConvertKanaOption = shape(
+  /**
+   * Convert "zen-kaku" alphabets to "han-kaku"
+   */
+  ?'r' => bool,
+  /**
+   * Convert "han-kaku" alphabets to "zen-kaku"
+   */
+  ?'R' => bool,
+  /**
+   * Convert "zen-kaku" numbers to "han-kaku"
+   */
+  ?'n' => bool,
+  /**
+   * Convert "han-kaku" numbers to "zen-kaku"
+   */
+  ?'N' => bool,
+  /**
+   * Convert "zen-kaku" alphabets and numbers to "han-kaku"
+   */
+  ?'a' => bool,
+  /**
+   * Convert "han-kaku" alphabets and numbers to "zen-kaku" (Characters
+   * included in "a", "A" options are U+0021 - U+007E excluding U+0022,
+   * U+0027, U+005C, U+007E)
+   */
+  ?'A' => bool,
+  /**
+   * Convert "zen-kaku" space to "han-kaku" (U+3000 -> U+0020)
+   */
+  ?'s' => bool,
+  /**
+   * Convert "han-kaku" space to "zen-kaku" (U+0020 -> U+3000)
+   */
+  ?'S' => bool,
+  /**
+   * Convert "zen-kaku kata-kana" to "han-kaku kata-kana"
+   */
+  ?'k' => bool,
+  /**
+   * Convert "han-kaku kata-kana" to "zen-kaku kata-kana"
+   */
+  ?'K' => bool,
+  /**
+   * Convert "zen-kaku hira-gana" to "han-kaku kata-kana"
+   */
+  ?'h' => bool,
+  /**
+   * Convert "han-kaku kata-kana" to "zen-kaku hira-gana"
+   */
+  ?'H' => bool,
+  /**
+   * Convert "zen-kaku kata-kana" to "zen-kaku hira-gana"
+   */
+  ?'c' => bool,
+  /**
+   * Convert "zen-kaku hira-gana" to "zen-kaku kata-kana"
+   */
+  ?'C' => bool,
+  /**
+   * Collapse voiced sound notation and convert them into a character.
+   * Use with "K", "H"
+   */
+  ?'V' => bool,
+);
+
 /**
  * Performs a "han-kaku" - "zen-kaku" conversion for string str. This function
  *   is only useful for Japanese.
  *
- *   Applicable Conversion Options
- *   Option Meaning
- *   r      Convert "zen-kaku" alphabets to "han-kaku"
- *   R      Convert "han-kaku" alphabets to "zen-kaku"
- *   n      Convert "zen-kaku" numbers to "han-kaku"
- *   N      Convert "han-kaku" numbers to "zen-kaku"
- *   a      Convert "zen-kaku" alphabets and numbers to "han-kaku"
- *   A      Convert "han-kaku" alphabets and numbers to "zen-kaku" (Characters
- *          included in "a", "A" options are U+0021 - U+007E excluding U+0022,
- *          U+0027, U+005C, U+007E)
- *   s      Convert "zen-kaku" space to "han-kaku" (U+3000 -> U+0020)
- *   S      Convert "han-kaku" space to "zen-kaku" (U+0020 -> U+3000)
- *   k      Convert "zen-kaku kata-kana" to "han-kaku kata-kana"
- *   K      Convert "han-kaku kata-kana" to "zen-kaku kata-kana"
- *   h      Convert "zen-kaku hira-gana" to "han-kaku kata-kana"
- *   H      Convert "han-kaku kata-kana" to "zen-kaku hira-gana"
- *   c      Convert "zen-kaku kata-kana" to "zen-kaku hira-gana"
- *   C      Convert "zen-kaku hira-gana" to "zen-kaku kata-kana"
- *   V      Collapse voiced sound notation and convert them into a character.
- *          Use with "K","H"
+ * See TConvertKanaOption for the list of options
  */
 <<__RxLocal>>
-function convert_kana(string $string, string $options): string {
-  return \mb_convert_kana($string, $options, Encoding::UTF8);
+function convert_kana(string $string, TConvertKanaOption $options): string {
+  // the native implementation wants a string containing all the options
+  // order does not matter
+  // take only true elements from the shape and join them
+  $option_string = Shapes::toDict($options)
+    |> Dict\filter($$)
+    |> Keyset\keys($$)
+    |> Str\join($$, '');
+
+  return \mb_convert_kana($string, $option_string, Encoding::UTF8);
 }
 
 /**
@@ -99,4 +154,3 @@ function splice(
   return
     slice($string, 0, $offset).$replacement.slice($string, $offset + $length);
 }
-

--- a/src/str/utf8/transform.php
+++ b/src/str/utf8/transform.php
@@ -99,3 +99,4 @@ function splice(
   return
     slice($string, 0, $offset).$replacement.slice($string, $offset + $length);
 }
+

--- a/src/str/utf8/transform.php
+++ b/src/str/utf8/transform.php
@@ -75,3 +75,26 @@ function convert_kana(string $string, string $options): string {
   return \mb_convert_kana($string, $options, Encoding::UTF8);
 }
 
+/**
+ * Return the string with a slice specified by the offset/length replaced by the
+ * given replacement string.
+ *
+ * If the length is omitted or exceeds the upper bound of the string, the
+ * remainder of the string will be replaced. If the length is zero, the
+ * replacement will be inserted at the offset.
+ */
+<<__RxLocal>>
+function splice(
+  string $string,
+  string $replacement,
+  int $offset,
+  ?int $length = null,
+): string {
+  invariant($length === null || $length >= 0, 'Expected non-negative length.');
+  $offset = _Private\validate_offset($offset, length($string));
+  if ($length === null) {
+    return slice($string, 0, $offset).$replacement;
+  }
+  return
+    slice($string, 0, $offset).$replacement.slice($string, $offset + $length);
+}

--- a/src/str/utf8/transform.php
+++ b/src/str/utf8/transform.php
@@ -1,0 +1,77 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Str\Utf8;
+
+use namespace HH\Lib\_Private;
+use type HH\Lib\Str\Encoding;
+
+/**
+ * Returns the string with all alphabetic characters converted to uppercase.
+ */
+<<__RxLocal>>
+function uppercase(string $string): string {
+  return \mb_strtoupper($string, Encoding::UTF8);
+}
+
+/**
+ * Returns the string with all alphabetic characters converted to lowercase.
+ */
+<<__RxLocal>>
+function lowercase(string $string): string {
+  return \mb_strtolower($string, Encoding::UTF8);
+}
+
+/**
+ * Convert the string from the specified encoding to UTF-8
+ */
+<<__RxLocal>>
+function from_encoding(string $string, Encoding $encoding): string {
+  return \mb_convert_encoding($string, Encoding::UTF8, $encoding);
+}
+
+/**
+ * Convert the string from UTF-8 to the specified encoding
+ */
+<<__RxLocal>>
+function to_encoding(string $string, Encoding $encoding): string {
+  return \mb_convert_encoding($string, $encoding, Encoding::UTF8);
+}
+
+/**
+ * Performs a "han-kaku" - "zen-kaku" conversion for string str. This function
+ *   is only useful for Japanese.
+ *
+ *   Applicable Conversion Options
+ *   Option Meaning
+ *   r      Convert "zen-kaku" alphabets to "han-kaku"
+ *   R      Convert "han-kaku" alphabets to "zen-kaku"
+ *   n      Convert "zen-kaku" numbers to "han-kaku"
+ *   N      Convert "han-kaku" numbers to "zen-kaku"
+ *   a      Convert "zen-kaku" alphabets and numbers to "han-kaku"
+ *   A      Convert "han-kaku" alphabets and numbers to "zen-kaku" (Characters
+ *          included in "a", "A" options are U+0021 - U+007E excluding U+0022,
+ *          U+0027, U+005C, U+007E)
+ *   s      Convert "zen-kaku" space to "han-kaku" (U+3000 -> U+0020)
+ *   S      Convert "han-kaku" space to "zen-kaku" (U+0020 -> U+3000)
+ *   k      Convert "zen-kaku kata-kana" to "han-kaku kata-kana"
+ *   K      Convert "han-kaku kata-kana" to "zen-kaku kata-kana"
+ *   h      Convert "zen-kaku hira-gana" to "han-kaku kata-kana"
+ *   H      Convert "han-kaku kata-kana" to "zen-kaku hira-gana"
+ *   c      Convert "zen-kaku kata-kana" to "zen-kaku hira-gana"
+ *   C      Convert "zen-kaku hira-gana" to "zen-kaku kata-kana"
+ *   V      Collapse voiced sound notation and convert them into a character.
+ *          Use with "K","H"
+ */
+<<__RxLocal>>
+function convert_kana(string $string, string $options): string {
+  return \mb_convert_kana($string, $options, Encoding::UTF8);
+}
+

--- a/src/str/utf8/transform.php
+++ b/src/str/utf8/transform.php
@@ -91,8 +91,9 @@ function splice(
   ?int $length = null,
 ): string {
   invariant($length === null || $length >= 0, 'Expected non-negative length.');
-  $offset = _Private\validate_offset($offset, length($string));
-  if ($length === null) {
+  $total_length = length($string);
+  $offset = _Private\validate_offset($offset, $total_length);
+  if ($length === null || ($offset + $length) >= $total_length) {
     return slice($string, 0, $offset).$replacement;
   }
   return

--- a/src/str/utf8/transform.php
+++ b/src/str/utf8/transform.php
@@ -8,10 +8,10 @@
  *
  */
 
-namespace HH\Lib\Str\Utf8;
+namespace HH\Lib\Experimental\Str\Utf8;
 
 use namespace HH\Lib\_Private;
-use type HH\Lib\Str\Encoding;
+use type HH\Lib\Experimental\Str\Encoding;
 
 /**
  * Returns the string with all alphabetic characters converted to uppercase.

--- a/tests/grapheme/GraphemeIntrospectTest.php
+++ b/tests/grapheme/GraphemeIntrospectTest.php
@@ -14,8 +14,8 @@ use function Facebook\FBExpect\expect;
 
 final class GraphemeIntrospectTest extends \Facebook\HackTest\HackTestCase {
 
-  public static function provideLength(): varray<mixed> {
-    return varray[
+  public static function provideLength(): vec<(string, int)> {
+    return vec[
       tuple('', 0),
       tuple('0', 1),
       tuple('hello', 5),
@@ -32,8 +32,8 @@ final class GraphemeIntrospectTest extends \Facebook\HackTest\HackTestCase {
     expect(Grapheme\length($string))->toBeSame($expected);
   }
 
-  public static function provideSearch(): varray<mixed> {
-    return varray[
+  public static function provideSearch(): vec<(string, string, int, ?int)> {
+    return vec[
       tuple('', 'foo', 0, null),
       tuple('foöBar', 'öB', 0, 2),
       tuple('foöBar', 'öB', 3, null),
@@ -60,8 +60,8 @@ final class GraphemeIntrospectTest extends \Facebook\HackTest\HackTestCase {
     expect(Grapheme\search($haystack, $needle, $offset))->toBeSame($expected);
   }
 
-  public static function provideSearchCI(): varray<mixed> {
-    return varray[
+  public static function provideSearchCI(): vec<(string, string, int, ?int)> {
+    return vec[
       tuple('', 'foo', 0, null),
       tuple('foöBar', 'öb', 0, 2),
       tuple('foöBar', 'öb', 3, null),

--- a/tests/grapheme/GraphemeIntrospectTest.php
+++ b/tests/grapheme/GraphemeIntrospectTest.php
@@ -22,16 +22,13 @@ final class GraphemeIntrospectTest extends PHPUnit_Framework_TestCase {
       tuple('مرحبا عالم', 10),
       tuple('héllö wôrld', 11),
       tuple('こんにちは世界', 7),
-	  tuple('👨‍👨‍👧‍👧', 1),
-	  tuple('각', 1),
+      tuple('👨‍👨‍👧‍👧', 1),
+      tuple('각', 1),
     ];
   }
 
   /** @dataProvider provideLength */
-  public function testLength(
-    string $string,
-    int $expected,
-  ): void {
+  public function testLength(string $string, int $expected): void {
     expect(Grapheme\length($string))->toBeSame($expected);
   }
 
@@ -44,7 +41,12 @@ final class GraphemeIntrospectTest extends PHPUnit_Framework_TestCase {
       tuple('foo', 'o', 3, null),
       tuple('héllö wôrld', 'ow', 0, null),
       tuple('héllö wôrld', 'wôrld', -3, null),
-	  tuple('🤷‍a👨‍👨‍👧‍👧‍‍‍', '👨‍👨‍👧‍👧‍‍‍', 0, 2),
+      tuple(
+        '🤷‍a👨‍👨‍👧‍👧‍‍‍',
+        '👨‍👨‍👧‍👧‍‍‍',
+        0,
+        2,
+      ),
     ];
   }
 
@@ -68,7 +70,12 @@ final class GraphemeIntrospectTest extends PHPUnit_Framework_TestCase {
       tuple('héllö wôrld', 'ow', 0, null),
       tuple('héllö wôrld', 'Wôrld', -3, null),
       tuple('héllö wôrld', 'WÔRLD', -5, 6),
-	  tuple('a👨‍👨‍👧‍👧', '👨‍👨‍👧‍👧‍‍‍', 0, 1),
+      tuple(
+        'a👨‍👨‍👧‍👧',
+        '👨‍👨‍👧‍👧‍‍‍',
+        0,
+        1,
+      ),
     ];
   }
 
@@ -79,7 +86,9 @@ final class GraphemeIntrospectTest extends PHPUnit_Framework_TestCase {
     int $offset,
     ?int $expected,
   ): void {
-    expect(Grapheme\search_ci($haystack, $needle, $offset))->toBeSame($expected);
+    expect(Grapheme\search_ci($haystack, $needle, $offset))->toBeSame(
+      $expected,
+    );
   }
 
   public function testPositionExceptions(): void {
@@ -94,3 +103,4 @@ final class GraphemeIntrospectTest extends PHPUnit_Framework_TestCase {
       ->toThrow(InvariantException::class);
   }
 }
+

--- a/tests/grapheme/GraphemeIntrospectTest.php
+++ b/tests/grapheme/GraphemeIntrospectTest.php
@@ -12,7 +12,7 @@ use namespace HH\Lib\Experimental\Str\Grapheme;
 use function Facebook\FBExpect\expect;
 // @oss-disable: use InvariantViolationException as InvariantException;
 
-final class GraphemeIntrospectTest extends \Facebook\HackTest\HackTestCase {
+final class GraphemeIntrospectTest extends \Facebook\HackTest\HackTest {
 
   public static function provideLength(): vec<(string, int)> {
     return vec[
@@ -26,7 +26,7 @@ final class GraphemeIntrospectTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideLength */
+  <<DataProvider('provideLength')>>
   public function testLength(string $string, int $expected): void {
     expect(Grapheme\length($string))->toBeSame($expected);
   }
@@ -49,7 +49,7 @@ final class GraphemeIntrospectTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideSearch */
+  <<DataProvider('provideSearch')>>
   public function testSearch(
     string $haystack,
     string $needle,
@@ -78,7 +78,7 @@ final class GraphemeIntrospectTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideSearchCI */
+  <<DataProvider('provideSearchCI')>>
   public function testSearchCI(
     string $haystack,
     string $needle,

--- a/tests/grapheme/GraphemeIntrospectTest.php
+++ b/tests/grapheme/GraphemeIntrospectTest.php
@@ -12,7 +12,7 @@ use namespace HH\Lib\Experimental\Str\Grapheme;
 use function Facebook\FBExpect\expect;
 // @oss-disable: use InvariantViolationException as InvariantException;
 
-final class GraphemeIntrospectTest extends PHPUnit_Framework_TestCase {
+final class GraphemeIntrospectTest extends \Facebook\HackTest\HackTestCase {
 
   public static function provideLength(): varray<mixed> {
     return varray[

--- a/tests/grapheme/GraphemeIntrospectTest.php
+++ b/tests/grapheme/GraphemeIntrospectTest.php
@@ -22,7 +22,6 @@ final class GraphemeIntrospectTest extends \Facebook\HackTest\HackTestCase {
       tuple('مرحبا عالم', 10),
       tuple('héllö wôrld', 11),
       tuple('こんにちは世界', 7),
-      tuple('👨‍👨‍👧‍👧', 1),
       tuple('각', 1),
     ];
   }

--- a/tests/grapheme/GraphemeSelectTest.php
+++ b/tests/grapheme/GraphemeSelectTest.php
@@ -15,7 +15,7 @@ use function Facebook\FBExpect\expect;
 /**
  * @emails oncall+hack
  */
-final class GraphemeSelectTest extends PHPUnit_Framework_TestCase {
+final class GraphemeSelectTest extends \Facebook\HackTest\HackTestCase {
 
   public static function provideSlice(): varray<mixed> {
     return varray[

--- a/tests/grapheme/GraphemeSelectTest.php
+++ b/tests/grapheme/GraphemeSelectTest.php
@@ -17,8 +17,8 @@ use function Facebook\FBExpect\expect;
  */
 final class GraphemeSelectTest extends \Facebook\HackTest\HackTestCase {
 
-  public static function provideSlice(): varray<mixed> {
-    return varray[
+  public static function provideSlice(): vec<(string, int, ?int, string)> {
+    return vec[
       tuple('héllö wôrld', 3, 3, 'lö '),
       tuple('héllö wôrld', 3, null, 'lö wôrld'),
       tuple('héllö wôrld', 3, 0, ''),
@@ -27,7 +27,12 @@ final class GraphemeSelectTest extends \Facebook\HackTest\HackTestCase {
       tuple('héllö wôrld', -5, null, 'wôrld'),
       tuple('héllö wôrld', -5, 100, 'wôrld'),
       tuple('héllö wôrld', -5, 3, 'wôr'),
-	  tuple('a👨‍👨‍👧‍👧 foo', 1, null, '👨‍👨‍👧‍👧 foo'),
+      tuple(
+        'a👨‍👨‍👧‍👧 foo',
+        1,
+        null,
+        '👨‍👨‍👧‍👧 foo',
+      ),
     ];
   }
 
@@ -50,11 +55,12 @@ final class GraphemeSelectTest extends \Facebook\HackTest\HackTestCase {
       ->toThrow(InvariantException::class);
   }
 
-  public static function provideExtract(): varray<mixed> {
-    return varray[
+  public static function provideExtract(
+  ): vec<(string, int, int, (string, int))> {
+    return vec[
       tuple('héllö wôrld', 1, 0, tuple('h', 1)),
-	  tuple('héllö wôrld', 1, 1, tuple('é', 3)),
-	  tuple('héllö wôrld', 3, 3, tuple('llö', 7)),
+      tuple('héllö wôrld', 1, 1, tuple('é', 3)),
+      tuple('héllö wôrld', 3, 3, tuple('llö', 7)),
     ];
   }
 
@@ -68,3 +74,4 @@ final class GraphemeSelectTest extends \Facebook\HackTest\HackTestCase {
     expect(Grapheme\extract($string, $offset, $next))->toBeSame($expected);
   }
 }
+

--- a/tests/grapheme/GraphemeSelectTest.php
+++ b/tests/grapheme/GraphemeSelectTest.php
@@ -15,7 +15,7 @@ use function Facebook\FBExpect\expect;
 /**
  * @emails oncall+hack
  */
-final class GraphemeSelectTest extends \Facebook\HackTest\HackTestCase {
+final class GraphemeSelectTest extends \Facebook\HackTest\HackTest {
 
   public static function provideSlice(): vec<(string, int, ?int, string)> {
     return vec[
@@ -36,7 +36,7 @@ final class GraphemeSelectTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideSlice */
+  <<DataProvider('provideSlice')>>
   public function testSlice(
     string $string,
     int $offset,
@@ -64,7 +64,7 @@ final class GraphemeSelectTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideExtract */
+  <<DataProvider('provideExtract')>>
   public function testExtract(
     string $string,
     int $offset,

--- a/tests/grapheme/GraphemeSelectTest.php
+++ b/tests/grapheme/GraphemeSelectTest.php
@@ -8,14 +8,14 @@
  *
  */
 
-use namespace HH\Lib\Experimental\Str\Utf8;
+use namespace HH\Lib\Experimental\Str\Grapheme;
 use function Facebook\FBExpect\expect;
 // @oss-disable: use InvariantViolationException as InvariantException;
 
 /**
  * @emails oncall+hack
  */
-final class Utf8SelectTest extends PHPUnit_Framework_TestCase {
+final class GraphemeSelectTest extends PHPUnit_Framework_TestCase {
 
   public static function provideSlice(): varray<mixed> {
     return varray[
@@ -27,6 +27,7 @@ final class Utf8SelectTest extends PHPUnit_Framework_TestCase {
       tuple('héllö wôrld', -5, null, 'wôrld'),
       tuple('héllö wôrld', -5, 100, 'wôrld'),
       tuple('héllö wôrld', -5, 3, 'wôr'),
+	  tuple('a👨‍👨‍👧‍👧 foo', 1, null, '👨‍👨‍👧‍👧 foo'),
     ];
   }
 
@@ -37,39 +38,33 @@ final class Utf8SelectTest extends PHPUnit_Framework_TestCase {
     ?int $length,
     string $expected,
   ): void {
-    expect(Utf8\slice($string, $offset, $length))->toBeSame($expected);
+    expect(Grapheme\slice($string, $offset, $length))->toBeSame($expected);
   }
 
   public function testSliceExceptions(): void {
-    expect(() ==> Utf8\slice('héllö', 0, -1))
+    expect(() ==> Grapheme\slice('héllö', 0, -1))
       ->toThrow(InvariantException::class);
-    expect(() ==> Utf8\slice('héllö', 10))
+    expect(() ==> Grapheme\slice('héllö', 10))
       ->toThrow(InvariantException::class);
-    expect(() ==> Utf8\slice('héllö', -6))
+    expect(() ==> Grapheme\slice('héllö', -6))
       ->toThrow(InvariantException::class);
   }
 
-  public static function provideSliceBytes(): varray<mixed> {
+  public static function provideExtract(): varray<mixed> {
     return varray[
-      tuple('héllö wôrld', 3, 3, 'll'),
-      tuple('héllö wôrld', 3, null, 'llö wôrld'),
-      tuple('héllö wôrld', 3, 0, ''),
-      tuple('fôo', 4, null, ''),
-      tuple('fôo', 4, 12, ''),
-      tuple('héllö wôrld', -5, null, 'ôrld'),
-      tuple('héllö wôrld', -5, 100, 'ôrld'),
-      tuple('héllö wôrld', -5, 3, 'ôr'),
+      tuple('héllö wôrld', 1, 0, tuple('h', 1)),
+	  tuple('héllö wôrld', 1, 1, tuple('é', 3)),
+	  tuple('héllö wôrld', 3, 3, tuple('llö', 7)),
     ];
   }
 
-  /** @dataProvider provideSliceBytes */
-  public function testSliceBytes(
+  /** @dataProvider provideExtract */
+  public function testExtract(
     string $string,
     int $offset,
-    ?int $length,
-    string $expected,
+    int $next,
+    (string, int) $expected,
   ): void {
-    expect(Utf8\slice_bytes($string, $offset, $length))->toBeSame($expected);
+    expect(Grapheme\extract($string, $offset, $next))->toBeSame($expected);
   }
 }
-

--- a/tests/grapheme/IntrospectTest.php
+++ b/tests/grapheme/IntrospectTest.php
@@ -1,0 +1,127 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use namespace HH\Lib\Experimental\Str\Grapheme;
+use function Facebook\FBExpect\expect;
+// @oss-disable: use InvariantViolationException as InvariantException;
+
+final class GraphemeIntrospectTest extends PHPUnit_Framework_TestCase {
+
+  public static function provideLength(): varray<mixed> {
+    return varray[
+      tuple('', 0),
+      tuple('0', 1),
+      tuple('hello', 5),
+      tuple('مرحبا عالم', 10),
+      tuple('héllö wôrld', 11),
+      tuple('こんにちは世界', 7),
+	  tuple('👨‍👨‍👧‍👧', 1),
+	  tuple('각', 1),
+    ];
+  }
+
+  /** @dataProvider provideLength */
+  public function testLength(
+    string $string,
+    int $expected,
+  ): void {
+    expect(Grapheme\length($string))->toBeSame($expected);
+  }
+
+  public static function provideSearch(): varray<mixed> {
+    return varray[
+      tuple('', 'foo', 0, null),
+      tuple('foöBar', 'öB', 0, 2),
+      tuple('foöBar', 'öB', 3, null),
+      tuple('foöbar', 'öB', 0, null),
+      tuple('foo', 'o', 3, null),
+      tuple('héllö wôrld', 'ow', 0, null),
+      tuple('héllö wôrld', 'wôrld', -3, null),
+	  tuple('a👨‍👨‍👧‍👧', '👨‍👨‍👧‍👧‍‍‍‍', 0, 1),
+    ];
+  }
+
+  /** @dataProvider provideSearch */
+  public function testSearch(
+    string $haystack,
+    string $needle,
+    int $offset,
+    ?int $expected,
+  ): void {
+    expect(Grapheme\search($haystack, $needle, $offset))->toBeSame($expected);
+  }
+
+  public static function provideSearchCI(): varray<mixed> {
+    return varray[
+      tuple('', 'foo', 0, null),
+      tuple('foöBar', 'öb', 0, 2),
+      tuple('foöBar', 'öb', 3, null),
+      tuple('foöbar', 'öB', 0, 2),
+      tuple('foo', 'o', 3, null),
+      tuple('héllö wôrld', 'ow', 0, null),
+      tuple('héllö wôrld', 'Wôrld', -3, null),
+      tuple('héllö wôrld', 'WÔRLD', -5, 6),
+	  tuple('a👨‍👨‍👧‍👧', '👨‍👨‍👧‍👧‍‍‍‍', 0, 1),
+    ];
+  }
+
+  /** @dataProvider provideSearchCI */
+  public function testSearchCI(
+    string $haystack,
+    string $needle,
+    int $offset,
+    ?int $expected,
+  ): void {
+    expect(Grapheme\search_ci($haystack, $needle, $offset))->toBeSame($expected);
+  }
+
+  public static function provideSearchLast(): varray<mixed> {
+    return varray[
+      tuple('foofoofoo', 'foo', 0, 6),
+      tuple('foofoofoo', 'bar', 0, null),
+      tuple('foobarbar', 'foo', 3, null),
+      tuple('foofoofoo', 'Foo', 0, null),
+      tuple('foo', 'o', 3, null),
+      tuple('foofoofoo', 'foo', -3, 6),
+      tuple('foofoofoo', 'foo', -4, 3),
+      tuple('héllö wôrld', 'wôrld', -3, 6),
+      tuple('héllö wôrld', 'wôrld', -5, 6),
+      tuple('héllö wôrld', 'wôrld', -6, null),
+	  tuple('a👨‍👨‍👧‍👧👨‍👨‍👧‍👧‍‍', '👨‍👨‍👧‍👧‍‍‍‍', 0, 2),
+    ];
+  }
+
+  /** @dataProvider provideSearchLast */
+  public function testSearchLast(
+    string $haystack,
+    string $needle,
+    int $offset,
+    ?int $expected,
+  ): void {
+    expect(Grapheme\search_last($haystack, $needle, $offset))->toBeSame($expected);
+  }
+
+  public function testPositionExceptions(): void {
+    expect(() ==> Grapheme\search('foo', 'f', 5))
+      ->toThrow(InvariantException::class);
+    expect(() ==> Grapheme\search('héllö wôrld', 'wôrld', -16))
+      ->toThrow(InvariantException::class);
+
+    expect(() ==> Grapheme\search_ci('foo', 'f', 5))
+      ->toThrow(InvariantException::class);
+    expect(() ==> Grapheme\search_ci('héllö wôrld', 'wôrld', -16))
+      ->toThrow(InvariantException::class);
+
+    expect(() ==> Grapheme\search_last('foo', 'f', 5))
+      ->toThrow(InvariantException::class);
+    expect(() ==> Grapheme\search_last('héllö wôrld', 'wôrld', -16))
+      ->toThrow(InvariantException::class);
+  }
+}

--- a/tests/grapheme/IntrospectTest.php
+++ b/tests/grapheme/IntrospectTest.php
@@ -44,7 +44,7 @@ final class GraphemeIntrospectTest extends PHPUnit_Framework_TestCase {
       tuple('foo', 'o', 3, null),
       tuple('héllö wôrld', 'ow', 0, null),
       tuple('héllö wôrld', 'wôrld', -3, null),
-	  tuple('a👨‍👨‍👧‍👧', '👨‍👨‍👧‍👧‍‍‍‍', 0, 1),
+	  tuple('🤷‍a👨‍👨‍👧‍👧‍‍‍', '👨‍👨‍👧‍👧‍‍‍', 0, 2),
     ];
   }
 
@@ -68,7 +68,7 @@ final class GraphemeIntrospectTest extends PHPUnit_Framework_TestCase {
       tuple('héllö wôrld', 'ow', 0, null),
       tuple('héllö wôrld', 'Wôrld', -3, null),
       tuple('héllö wôrld', 'WÔRLD', -5, 6),
-	  tuple('a👨‍👨‍👧‍👧', '👨‍👨‍👧‍👧‍‍‍‍', 0, 1),
+	  tuple('a👨‍👨‍👧‍👧', '👨‍👨‍👧‍👧‍‍‍', 0, 1),
     ];
   }
 
@@ -82,32 +82,6 @@ final class GraphemeIntrospectTest extends PHPUnit_Framework_TestCase {
     expect(Grapheme\search_ci($haystack, $needle, $offset))->toBeSame($expected);
   }
 
-  public static function provideSearchLast(): varray<mixed> {
-    return varray[
-      tuple('foofoofoo', 'foo', 0, 6),
-      tuple('foofoofoo', 'bar', 0, null),
-      tuple('foobarbar', 'foo', 3, null),
-      tuple('foofoofoo', 'Foo', 0, null),
-      tuple('foo', 'o', 3, null),
-      tuple('foofoofoo', 'foo', -3, 6),
-      tuple('foofoofoo', 'foo', -4, 3),
-      tuple('héllö wôrld', 'wôrld', -3, 6),
-      tuple('héllö wôrld', 'wôrld', -5, 6),
-      tuple('héllö wôrld', 'wôrld', -6, null),
-	  tuple('a👨‍👨‍👧‍👧👨‍👨‍👧‍👧‍‍', '👨‍👨‍👧‍👧‍‍‍‍', 0, 2),
-    ];
-  }
-
-  /** @dataProvider provideSearchLast */
-  public function testSearchLast(
-    string $haystack,
-    string $needle,
-    int $offset,
-    ?int $expected,
-  ): void {
-    expect(Grapheme\search_last($haystack, $needle, $offset))->toBeSame($expected);
-  }
-
   public function testPositionExceptions(): void {
     expect(() ==> Grapheme\search('foo', 'f', 5))
       ->toThrow(InvariantException::class);
@@ -117,11 +91,6 @@ final class GraphemeIntrospectTest extends PHPUnit_Framework_TestCase {
     expect(() ==> Grapheme\search_ci('foo', 'f', 5))
       ->toThrow(InvariantException::class);
     expect(() ==> Grapheme\search_ci('héllö wôrld', 'wôrld', -16))
-      ->toThrow(InvariantException::class);
-
-    expect(() ==> Grapheme\search_last('foo', 'f', 5))
-      ->toThrow(InvariantException::class);
-    expect(() ==> Grapheme\search_last('héllö wôrld', 'wôrld', -16))
       ->toThrow(InvariantException::class);
   }
 }

--- a/tests/utf8/Utf8IntrospectTest.php
+++ b/tests/utf8/Utf8IntrospectTest.php
@@ -12,7 +12,7 @@ use namespace HH\Lib\Experimental\Str\Utf8;
 use function Facebook\FBExpect\expect;
 // @oss-disable: use InvariantViolationException as InvariantException;
 
-final class Utf8IntrospectTest extends \Facebook\HackTest\HackTestCase {
+final class Utf8IntrospectTest extends \Facebook\HackTest\HackTest {
 
   public static function provideLength(): vec<(string, int)> {
     return vec[
@@ -25,7 +25,7 @@ final class Utf8IntrospectTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideLength */
+  <<DataProvider('provideLength')>>
   public function testLength(string $string, int $expected): void {
     expect(Utf8\length($string))->toBeSame($expected);
   }
@@ -43,7 +43,7 @@ final class Utf8IntrospectTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideSearch */
+  <<DataProvider('provideSearch')>>
   public function testSearch(
     string $haystack,
     string $needle,
@@ -66,7 +66,7 @@ final class Utf8IntrospectTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideSearchCI */
+  <<DataProvider('provideSearchCI')>>
   public function testSearchCI(
     string $haystack,
     string $needle,
@@ -91,7 +91,7 @@ final class Utf8IntrospectTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideSearchLast */
+  <<DataProvider('provideSearchLast')>>
   public function testSearchLast(
     string $haystack,
     string $needle,
@@ -131,7 +131,7 @@ final class Utf8IntrospectTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideIsUtf8 */
+  <<DataProvider('provideIsUtf8')>>
   public function testIsUtf8(string $string, bool $expected): void {
     expect(Utf8\is_utf8($string))->toBeSame($expected);
   }

--- a/tests/utf8/Utf8IntrospectTest.php
+++ b/tests/utf8/Utf8IntrospectTest.php
@@ -12,7 +12,7 @@ use namespace HH\Lib\Experimental\Str\Utf8;
 use function Facebook\FBExpect\expect;
 // @oss-disable: use InvariantViolationException as InvariantException;
 
-final class Utf8IntrospectTest extends PHPUnit_Framework_TestCase {
+final class Utf8IntrospectTest extends \Facebook\HackTest\HackTestCase {
 
   public static function provideLength(): varray<mixed> {
     return varray[

--- a/tests/utf8/Utf8IntrospectTest.php
+++ b/tests/utf8/Utf8IntrospectTest.php
@@ -14,8 +14,8 @@ use function Facebook\FBExpect\expect;
 
 final class Utf8IntrospectTest extends \Facebook\HackTest\HackTestCase {
 
-  public static function provideLength(): varray<mixed> {
-    return varray[
+  public static function provideLength(): vec<(string, int)> {
+    return vec[
       tuple('', 0),
       tuple('0', 1),
       tuple('hello', 5),
@@ -30,8 +30,8 @@ final class Utf8IntrospectTest extends \Facebook\HackTest\HackTestCase {
     expect(Utf8\length($string))->toBeSame($expected);
   }
 
-  public static function provideSearch(): varray<mixed> {
-    return varray[
+  public static function provideSearch(): vec<(string, string, int, ?int)> {
+    return vec[
       tuple('', 'foo', 0, null),
       tuple('foöBar', 'öB', 0, 2),
       tuple('foöBar', 'öB', 3, null),
@@ -53,8 +53,8 @@ final class Utf8IntrospectTest extends \Facebook\HackTest\HackTestCase {
     expect(Utf8\search($haystack, $needle, $offset))->toBeSame($expected);
   }
 
-  public static function provideSearchCI(): varray<mixed> {
-    return varray[
+  public static function provideSearchCI(): vec<(string, string, int, ?int)> {
+    return vec[
       tuple('', 'foo', 0, null),
       tuple('foöBar', 'öb', 0, 2),
       tuple('foöBar', 'öb', 3, null),
@@ -76,8 +76,8 @@ final class Utf8IntrospectTest extends \Facebook\HackTest\HackTestCase {
     expect(Utf8\search_ci($haystack, $needle, $offset))->toBeSame($expected);
   }
 
-  public static function provideSearchLast(): varray<mixed> {
-    return varray[
+  public static function provideSearchLast(): vec<(string, string, int, ?int)> {
+    return vec[
       tuple('foofoofoo', 'foo', 0, 6),
       tuple('foofoofoo', 'bar', 0, null),
       tuple('foobarbar', 'foo', 3, null),
@@ -118,8 +118,8 @@ final class Utf8IntrospectTest extends \Facebook\HackTest\HackTestCase {
       ->toThrow(InvariantException::class);
   }
 
-  public static function provideIsUtf8(): varray<mixed> {
-    return varray[
+  public static function provideIsUtf8(): vec<(string, bool)> {
+    return vec[
       tuple('', true),
       tuple('foo', true),
       tuple('مرحبا عالم', true),

--- a/tests/utf8/Utf8IntrospectTest.php
+++ b/tests/utf8/Utf8IntrospectTest.php
@@ -1,0 +1,145 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use namespace HH\Lib\Experimental\Str\Utf8;
+use function Facebook\FBExpect\expect;
+// @oss-disable: use InvariantViolationException as InvariantException;
+
+final class Utf8IntrospectTest extends PHPUnit_Framework_TestCase {
+
+  public static function provideLength(): varray<mixed> {
+    return varray[
+      tuple('', 0),
+      tuple('0', 1),
+      tuple('hello', 5),
+      tuple('مرحبا عالم', 10),
+      tuple('héllö wôrld', 11),
+      tuple('こんにちは世界', 7),
+    ];
+  }
+
+  /** @dataProvider provideLength */
+  public function testLength(
+    string $string,
+    int $expected,
+  ): void {
+    expect(Utf8\length($string))->toBeSame($expected);
+  }
+
+  public static function provideSearch(): varray<mixed> {
+    return varray[
+      tuple('', 'foo', 0, null),
+      tuple('foöBar', 'öB', 0, 2),
+      tuple('foöBar', 'öB', 3, null),
+      tuple('foöbar', 'öB', 0, null),
+      tuple('foo', 'o', 3, null),
+      tuple('héllö wôrld', 'ow', 0, null),
+      tuple('héllö wôrld', 'wôrld', -3, null),
+      tuple('héllö wôrld', 'wôrld', -5, 6),
+    ];
+  }
+
+  /** @dataProvider provideSearch */
+  public function testSearch(
+    string $haystack,
+    string $needle,
+    int $offset,
+    ?int $expected,
+  ): void {
+    expect(Utf8\search($haystack, $needle, $offset))->toBeSame($expected);
+  }
+
+  public static function provideSearchCI(): varray<mixed> {
+    return varray[
+      tuple('', 'foo', 0, null),
+      tuple('foöBar', 'öb', 0, 2),
+      tuple('foöBar', 'öb', 3, null),
+      tuple('foöbar', 'öB', 0, 2),
+      tuple('foo', 'o', 3, null),
+      tuple('héllö wôrld', 'ow', 0, null),
+      tuple('héllö wôrld', 'Wôrld', -3, null),
+      tuple('héllö wôrld', 'WÔRLD', -5, 6),
+    ];
+  }
+
+  /** @dataProvider provideSearchCI */
+  public function testSearchCI(
+    string $haystack,
+    string $needle,
+    int $offset,
+    ?int $expected,
+  ): void {
+    expect(Utf8\search_ci($haystack, $needle, $offset))->toBeSame($expected);
+  }
+
+  public static function provideSearchLast(): varray<mixed> {
+    return varray[
+      tuple('foofoofoo', 'foo', 0, 6),
+      tuple('foofoofoo', 'bar', 0, null),
+      tuple('foobarbar', 'foo', 3, null),
+      tuple('foofoofoo', 'Foo', 0, null),
+      tuple('foo', 'o', 3, null),
+      tuple('foofoofoo', 'foo', -3, 6),
+      tuple('foofoofoo', 'foo', -4, 3),
+      tuple('héllö wôrld', 'wôrld', -3, 6),
+      tuple('héllö wôrld', 'wôrld', -5, 6),
+      tuple('héllö wôrld', 'wôrld', -6, null),
+    ];
+  }
+
+  /** @dataProvider provideSearchLast */
+  public function testSearchLast(
+    string $haystack,
+    string $needle,
+    int $offset,
+    ?int $expected,
+  ): void {
+    expect(Utf8\search_last($haystack, $needle, $offset))->toBeSame($expected);
+  }
+
+  public function testPositionExceptions(): void {
+    expect(() ==> Utf8\search('foo', 'f', 5))
+      ->toThrow(InvariantException::class);
+    expect(() ==> Utf8\search('héllö wôrld', 'wôrld', -16))
+      ->toThrow(InvariantException::class);
+
+    expect(() ==> Utf8\search_ci('foo', 'f', 5))
+      ->toThrow(InvariantException::class);
+    expect(() ==> Utf8\search_ci('héllö wôrld', 'wôrld', -16))
+      ->toThrow(InvariantException::class);
+
+    expect(() ==> Utf8\search_last('foo', 'f', 5))
+      ->toThrow(InvariantException::class);
+    expect(() ==> Utf8\search_last('héllö wôrld', 'wôrld', -16))
+      ->toThrow(InvariantException::class);
+  }
+
+  public static function provideIsUtf8(): varray<mixed> {
+    return varray[
+      tuple('', true),
+      tuple('foo', true),
+      tuple('مرحبا عالم', true),
+      tuple('héllö wôrld', true),
+      tuple('こんにちは世界', true),
+      tuple("h\351ll\366 w\364rld", false),
+      tuple("\xc3\x28", false),
+      tuple("\xf0\x28\x8c\x28", false),
+    ];
+  }
+
+  /** @dataProvider provideIsUtf8 */
+  public function testIsUtf8(
+    string $string,
+    bool $expected
+  ): void {
+    expect(Utf8\is_utf8($string))->toBeSame($expected);
+  }
+
+}

--- a/tests/utf8/Utf8IntrospectTest.php
+++ b/tests/utf8/Utf8IntrospectTest.php
@@ -26,10 +26,7 @@ final class Utf8IntrospectTest extends PHPUnit_Framework_TestCase {
   }
 
   /** @dataProvider provideLength */
-  public function testLength(
-    string $string,
-    int $expected,
-  ): void {
+  public function testLength(string $string, int $expected): void {
     expect(Utf8\length($string))->toBeSame($expected);
   }
 
@@ -135,11 +132,9 @@ final class Utf8IntrospectTest extends PHPUnit_Framework_TestCase {
   }
 
   /** @dataProvider provideIsUtf8 */
-  public function testIsUtf8(
-    string $string,
-    bool $expected
-  ): void {
+  public function testIsUtf8(string $string, bool $expected): void {
     expect(Utf8\is_utf8($string))->toBeSame($expected);
   }
 
 }
+

--- a/tests/utf8/Utf8SelectTest.php
+++ b/tests/utf8/Utf8SelectTest.php
@@ -15,7 +15,7 @@ use function Facebook\FBExpect\expect;
 /**
  * @emails oncall+hack
  */
-final class Utf8SelectTest extends PHPUnit_Framework_TestCase {
+final class Utf8SelectTest extends \Facebook\HackTest\HackTestCase {
 
   public static function provideSlice(): varray<mixed> {
     return varray[

--- a/tests/utf8/Utf8SelectTest.php
+++ b/tests/utf8/Utf8SelectTest.php
@@ -17,8 +17,8 @@ use function Facebook\FBExpect\expect;
  */
 final class Utf8SelectTest extends \Facebook\HackTest\HackTestCase {
 
-  public static function provideSlice(): varray<mixed> {
-    return varray[
+  public static function provideSlice(): vec<(string, int, ?int, string)> {
+    return vec[
       tuple('héllö wôrld', 3, 3, 'lö '),
       tuple('héllö wôrld', 3, null, 'lö wôrld'),
       tuple('héllö wôrld', 3, 0, ''),
@@ -49,8 +49,8 @@ final class Utf8SelectTest extends \Facebook\HackTest\HackTestCase {
       ->toThrow(InvariantException::class);
   }
 
-  public static function provideSliceBytes(): varray<mixed> {
-    return varray[
+  public static function provideSliceBytes(): vec<(string, int, ?int, string)> {
+    return vec[
       tuple('héllö wôrld', 3, 3, 'll'),
       tuple('héllö wôrld', 3, null, 'llö wôrld'),
       tuple('héllö wôrld', 3, 0, ''),

--- a/tests/utf8/Utf8SelectTest.php
+++ b/tests/utf8/Utf8SelectTest.php
@@ -15,7 +15,7 @@ use function Facebook\FBExpect\expect;
 /**
  * @emails oncall+hack
  */
-final class Utf8SelectTest extends \Facebook\HackTest\HackTestCase {
+final class Utf8SelectTest extends \Facebook\HackTest\HackTest {
 
   public static function provideSlice(): vec<(string, int, ?int, string)> {
     return vec[
@@ -30,7 +30,7 @@ final class Utf8SelectTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideSlice */
+  <<DataProvider('provideSlice')>>
   public function testSlice(
     string $string,
     int $offset,
@@ -62,7 +62,7 @@ final class Utf8SelectTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideSliceBytes */
+  <<DataProvider('provideSliceBytes')>>
   public function testSliceBytes(
     string $string,
     int $offset,

--- a/tests/utf8/Utf8SelectTest.php
+++ b/tests/utf8/Utf8SelectTest.php
@@ -1,0 +1,154 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use namespace HH\Lib\Experimental\Str\Utf8;
+use function Facebook\FBExpect\expect;
+// @oss-disable: use InvariantViolationException as InvariantException;
+
+/**
+ * @emails oncall+hack
+ */
+final class Utf8SelectTest extends PHPUnit_Framework_TestCase {
+
+  public static function provideSlice(): varray<mixed> {
+    return varray[
+      tuple(
+        'héllö wôrld',
+        3,
+        3,
+        'lö ',
+      ),
+      tuple(
+        'héllö wôrld',
+        3,
+        null,
+        'lö wôrld',
+      ),
+      tuple(
+        'héllö wôrld',
+        3,
+        0,
+        '',
+      ),
+      tuple(
+        'fôo',
+        3,
+        null,
+        '',
+      ),
+      tuple(
+        'fôo',
+        3,
+        12,
+        '',
+      ),
+      tuple(
+        'héllö wôrld',
+        -5,
+        null,
+        'wôrld',
+      ),
+      tuple(
+        'héllö wôrld',
+        -5,
+        100,
+        'wôrld',
+      ),
+      tuple(
+        'héllö wôrld',
+        -5,
+        3,
+        'wôr',
+      ),
+    ];
+  }
+
+  /** @dataProvider provideSlice */
+  public function testSlice(
+    string $string,
+    int $offset,
+    ?int $length,
+    string $expected,
+  ): void {
+    expect(Utf8\slice($string, $offset, $length))->toBeSame($expected);
+  }
+
+  public function testSliceExceptions(): void {
+    expect(() ==> Utf8\slice('héllö', 0, -1))
+      ->toThrow(InvariantException::class);
+    expect(() ==> Utf8\slice('héllö', 10))
+      ->toThrow(InvariantException::class);
+    expect(() ==> Utf8\slice('héllö', -6))
+      ->toThrow(InvariantException::class);
+  }
+
+  public static function provideSliceBytes(): varray<mixed> {
+    return varray[
+      tuple(
+        'héllö wôrld',
+        3,
+        3,
+        'll',
+      ),
+      tuple(
+        'héllö wôrld',
+        3,
+        null,
+        'llö wôrld',
+      ),
+      tuple(
+        'héllö wôrld',
+        3,
+        0,
+        '',
+      ),
+      tuple(
+        'fôo',
+        4,
+        null,
+        '',
+      ),
+      tuple(
+        'fôo',
+        4,
+        12,
+        '',
+      ),
+      tuple(
+        'héllö wôrld',
+        -5,
+        null,
+        'ôrld',
+      ),
+      tuple(
+        'héllö wôrld',
+        -5,
+        100,
+        'ôrld',
+      ),
+      tuple(
+        'héllö wôrld',
+        -5,
+        3,
+        'ôr',
+      ),
+    ];
+  }
+
+  /** @dataProvider provideSliceBytes */
+  public function testSliceBytes(
+    string $string,
+    int $offset,
+    ?int $length,
+    string $expected,
+  ): void {
+    expect(Utf8\slice_bytes($string, $offset, $length))->toBeSame($expected);
+  }
+}

--- a/tests/utf8/Utf8TransformTest.php
+++ b/tests/utf8/Utf8TransformTest.php
@@ -95,7 +95,8 @@ final class Utf8TransformTest extends \Facebook\HackTest\HackTestCase {
 
   /** @dataProvider provideConvertKana */
   public function testConvertKana(string $string, string $expected): void {
-    expect(Utf8\convert_kana($string, 'kva'))->toBeSame($expected);
+    expect(Utf8\convert_kana($string, shape('k' => true, 'a' => true)))
+      ->toBeSame($expected);
   }
 
   public static function provideEncoding(): varray<mixed> {
@@ -131,4 +132,3 @@ final class Utf8TransformTest extends \Facebook\HackTest\HackTestCase {
   }
 
 }
-

--- a/tests/utf8/Utf8TransformTest.php
+++ b/tests/utf8/Utf8TransformTest.php
@@ -13,7 +13,7 @@ use function Facebook\FBExpect\expect;
 use type HH\Lib\Experimental\Str\Encoding;
 // @oss-disable: use InvariantViolationException as InvariantException;
 
-final class Utf8TransformTest extends \Facebook\HackTest\HackTestCase {
+final class Utf8TransformTest extends \Facebook\HackTest\HackTest {
 
   public static function provideLowercase(): vec<(string, string)> {
     return vec[
@@ -25,7 +25,7 @@ final class Utf8TransformTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideLowercase */
+  <<DataProvider('provideLowercase')>>
   public function testLowercase(string $string, string $expected): void {
     expect(Utf8\lowercase($string))->toBeSame($expected);
   }
@@ -40,7 +40,7 @@ final class Utf8TransformTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideUppercase */
+  <<DataProvider('provideUppercase')>>
   public function testUppercase(string $string, string $expected): void {
     expect(Utf8\uppercase($string))->toBeSame($expected);
   }
@@ -59,7 +59,7 @@ final class Utf8TransformTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideSplice */
+  <<DataProvider('provideSplice')>>
   public function testSplice(
     string $string,
     string $replacement,
@@ -94,7 +94,7 @@ final class Utf8TransformTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideConvertKana */
+  <<DataProvider('provideConvertKana')>>
   public function testConvertKana(string $string, string $expected): void {
     expect(Utf8\convert_kana($string, shape('k' => true, 'a' => true)))
       ->toBeSame($expected);
@@ -114,7 +114,7 @@ final class Utf8TransformTest extends \Facebook\HackTest\HackTestCase {
     ];
   }
 
-  /** @dataProvider provideEncoding */
+  <<DataProvider('provideEncoding')>>
   public function testFromEncoding(
     string $string,
     Encoding $encoding,
@@ -123,7 +123,7 @@ final class Utf8TransformTest extends \Facebook\HackTest\HackTestCase {
     expect(Utf8\from_encoding($string, $encoding))->toBeSame($expected);
   }
 
-  /** @dataProvider provideEncoding */
+  <<DataProvider('provideEncoding')>>
   public function testToEncoding(
     string $expected,
     Encoding $encoding,

--- a/tests/utf8/Utf8TransformTest.php
+++ b/tests/utf8/Utf8TransformTest.php
@@ -1,0 +1,180 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use namespace HH\Lib\Experimental\Str\Utf8;
+use function Facebook\FBExpect\expect;
+use type HH\Lib\Experimental\Str\Encoding;
+// @oss-disable: use InvariantViolationException as InvariantException;
+
+final class Utf8TransformTest extends PHPUnit_Framework_TestCase {
+
+  public static function provideLowercase(): varray<mixed> {
+    return varray[
+      tuple('', ''),
+      tuple('hello world', 'hello world'),
+      tuple('Hello World', 'hello world'),
+      tuple('Jenny: (???)-867-5309', 'jenny: (???)-867-5309'),
+	  tuple('HÉLLÖ Wôrld', 'héllö wôrld'),
+    ];
+  }
+
+  /** @dataProvider provideLowercase */
+  public function testLowercase(
+    string $string,
+    string $expected,
+  ): void {
+    expect(Utf8\lowercase($string))->toBeSame($expected);
+  }
+
+  public static function provideUppercase(): varray<mixed> {
+    return varray[
+      tuple('', ''),
+      tuple('hello world', 'HELLO WORLD'),
+      tuple('Hello World', 'HELLO WORLD'),
+      tuple('Jenny: (???)-867-5309', 'JENNY: (???)-867-5309'),
+	  tuple('héllö wôrld', 'HÉLLÖ WÔRLD'),
+    ];
+  }
+
+  /** @dataProvider provideUppercase */
+  public function testUppercase(
+    string $string,
+    string $expected,
+  ): void {
+    expect(Utf8\uppercase($string))->toBeSame($expected);
+  }
+
+  public static function provideSplice(): varray<mixed> {
+    return varray[
+      tuple(
+        '',
+        '',
+        0,
+        null,
+        '',
+      ),
+      tuple(
+        'héllö wôrld',
+        'darkness',
+        6,
+        null,
+        'héllö darkness',
+      ),
+      tuple(
+        'héllö wôrld',
+        ' crüel ',
+        5,
+        1,
+        'héllö crüel wôrld',
+      ),
+      tuple(
+        'héllö wôrld',
+        ' crüel ',
+        -6,
+        1,
+        'héllö crüel wôrld',
+      ),
+      tuple(
+        'héllö wôrld',
+        ' crüel',
+        5,
+        0,
+        'héllö crüel wôrld',
+      ),
+      tuple(
+        'héllö ',
+        'darkness',
+        6,
+        null,
+        'héllö darkness',
+      ),
+      tuple(
+        'héllö wôrld',
+        'darkness',
+        6,
+        100,
+        'héllö darkness',
+      ),
+      tuple(
+        'héllö wôrld',
+        'darkness',
+        6,
+        11,
+        'héllö darkness',
+      ),
+    ];
+  }
+
+  /** @dataProvider provideSplice */
+  public function testSplice(
+    string $string,
+    string $replacement,
+    int $offset,
+    ?int $length,
+    string $expected,
+  ): void {
+    expect(Utf8\splice($string, $replacement, $offset, $length))
+      ->toBeSame($expected);
+  }
+
+  public function testSpliceExceptions(): void {
+    expect(() ==> Utf8\splice('héllö wôrld', ' crüel ', -12, 1))
+      ->toThrow(InvariantException::class);
+    expect(() ==> Utf8\splice('héllö wôrld', ' crüel ', 100, 1))
+      ->toThrow(InvariantException::class);
+  }
+
+  public static function provideConvertKana(): varray<mixed> {
+    return varray[
+      tuple('', ''),
+      tuple('開発第１-ローカライゼーション', '開発第1-ﾛｰｶﾗｲｾﾞｰｼｮﾝ'),
+      tuple('開発第1-ﾛｰｶﾗｲｾﾞｰｼｮﾝ', '開発第1-ﾛｰｶﾗｲｾﾞｰｼｮﾝ'),
+      tuple('hello world', 'hello world'),
+	  tuple('héllö wôrld', 'héllö wôrld'),
+    ];
+  }
+
+  /** @dataProvider provideConvertKana */
+  public function testConvertKana(
+    string $string,
+    string $expected,
+  ): void {
+    expect(Utf8\convert_kana($string, 'kva'))->toBeSame($expected);
+  }
+
+  public static function provideEncoding(): varray<mixed> {
+    return varray[
+      tuple('', Encoding::ASCII, ''),
+      tuple("\006E\0061\006-\006(\006'\000 \0069\006'\006D\006E", Encoding::UCS2, 'مرحبا عالم'),
+      tuple("h\351ll\366 w\364rld", Encoding::ISO_8859_1, 'héllö wôrld'),
+      tuple('hello world', Encoding::ASCII, 'hello world'),
+	    tuple('héllö wôrld', Encoding::UTF8, 'héllö wôrld'),
+    ];
+  }
+
+  /** @dataProvider provideEncoding */
+  public function testFromEncoding(
+    string $string,
+    Encoding $encoding,
+    string $expected,
+  ): void {
+    expect(Utf8\from_encoding($string, $encoding))->toBeSame($expected);
+  }
+
+  /** @dataProvider provideEncoding */
+  public function testToEncoding(
+    string $expected,
+    Encoding $encoding,
+    string $string,
+  ): void {
+    expect(Utf8\to_encoding($string, $encoding))->toBeSame($expected);
+  }
+
+}

--- a/tests/utf8/Utf8TransformTest.php
+++ b/tests/utf8/Utf8TransformTest.php
@@ -21,15 +21,12 @@ final class Utf8TransformTest extends PHPUnit_Framework_TestCase {
       tuple('hello world', 'hello world'),
       tuple('Hello World', 'hello world'),
       tuple('Jenny: (???)-867-5309', 'jenny: (???)-867-5309'),
-	  tuple('HÉLLÖ Wôrld', 'héllö wôrld'),
+      tuple('HÉLLÖ Wôrld', 'héllö wôrld'),
     ];
   }
 
   /** @dataProvider provideLowercase */
-  public function testLowercase(
-    string $string,
-    string $expected,
-  ): void {
+  public function testLowercase(string $string, string $expected): void {
     expect(Utf8\lowercase($string))->toBeSame($expected);
   }
 
@@ -39,76 +36,25 @@ final class Utf8TransformTest extends PHPUnit_Framework_TestCase {
       tuple('hello world', 'HELLO WORLD'),
       tuple('Hello World', 'HELLO WORLD'),
       tuple('Jenny: (???)-867-5309', 'JENNY: (???)-867-5309'),
-	  tuple('héllö wôrld', 'HÉLLÖ WÔRLD'),
+      tuple('héllö wôrld', 'HÉLLÖ WÔRLD'),
     ];
   }
 
   /** @dataProvider provideUppercase */
-  public function testUppercase(
-    string $string,
-    string $expected,
-  ): void {
+  public function testUppercase(string $string, string $expected): void {
     expect(Utf8\uppercase($string))->toBeSame($expected);
   }
 
   public static function provideSplice(): varray<mixed> {
     return varray[
-      tuple(
-        '',
-        '',
-        0,
-        null,
-        '',
-      ),
-      tuple(
-        'héllö wôrld',
-        'darkness',
-        6,
-        null,
-        'héllö darkness',
-      ),
-      tuple(
-        'héllö wôrld',
-        ' crüel ',
-        5,
-        1,
-        'héllö crüel wôrld',
-      ),
-      tuple(
-        'héllö wôrld',
-        ' crüel ',
-        -6,
-        1,
-        'héllö crüel wôrld',
-      ),
-      tuple(
-        'héllö wôrld',
-        ' crüel',
-        5,
-        0,
-        'héllö crüel wôrld',
-      ),
-      tuple(
-        'héllö ',
-        'darkness',
-        6,
-        null,
-        'héllö darkness',
-      ),
-      tuple(
-        'héllö wôrld',
-        'darkness',
-        6,
-        100,
-        'héllö darkness',
-      ),
-      tuple(
-        'héllö wôrld',
-        'darkness',
-        6,
-        11,
-        'héllö darkness',
-      ),
+      tuple('', '', 0, null, ''),
+      tuple('héllö wôrld', 'darkness', 6, null, 'héllö darkness'),
+      tuple('héllö wôrld', ' crüel ', 5, 1, 'héllö crüel wôrld'),
+      tuple('héllö wôrld', ' crüel ', -6, 1, 'héllö crüel wôrld'),
+      tuple('héllö wôrld', ' crüel', 5, 0, 'héllö crüel wôrld'),
+      tuple('héllö ', 'darkness', 6, null, 'héllö darkness'),
+      tuple('héllö wôrld', 'darkness', 6, 100, 'héllö darkness'),
+      tuple('héllö wôrld', 'darkness', 6, 11, 'héllö darkness'),
     ];
   }
 
@@ -134,28 +80,35 @@ final class Utf8TransformTest extends PHPUnit_Framework_TestCase {
   public static function provideConvertKana(): varray<mixed> {
     return varray[
       tuple('', ''),
-      tuple('開発第１-ローカライゼーション', '開発第1-ﾛｰｶﾗｲｾﾞｰｼｮﾝ'),
-      tuple('開発第1-ﾛｰｶﾗｲｾﾞｰｼｮﾝ', '開発第1-ﾛｰｶﾗｲｾﾞｰｼｮﾝ'),
+      tuple(
+        '開発第１-ローカライゼーション',
+        '開発第1-ﾛｰｶﾗｲｾﾞｰｼｮﾝ',
+      ),
+      tuple(
+        '開発第1-ﾛｰｶﾗｲｾﾞｰｼｮﾝ',
+        '開発第1-ﾛｰｶﾗｲｾﾞｰｼｮﾝ',
+      ),
       tuple('hello world', 'hello world'),
-	  tuple('héllö wôrld', 'héllö wôrld'),
+      tuple('héllö wôrld', 'héllö wôrld'),
     ];
   }
 
   /** @dataProvider provideConvertKana */
-  public function testConvertKana(
-    string $string,
-    string $expected,
-  ): void {
+  public function testConvertKana(string $string, string $expected): void {
     expect(Utf8\convert_kana($string, 'kva'))->toBeSame($expected);
   }
 
   public static function provideEncoding(): varray<mixed> {
     return varray[
       tuple('', Encoding::ASCII, ''),
-      tuple("\006E\0061\006-\006(\006'\000 \0069\006'\006D\006E", Encoding::UCS2, 'مرحبا عالم'),
+      tuple(
+        "\006E\0061\006-\006(\006'\000 \0069\006'\006D\006E",
+        Encoding::UCS2,
+        'مرحبا عالم',
+      ),
       tuple("h\351ll\366 w\364rld", Encoding::ISO_8859_1, 'héllö wôrld'),
       tuple('hello world', Encoding::ASCII, 'hello world'),
-	    tuple('héllö wôrld', Encoding::UTF8, 'héllö wôrld'),
+      tuple('héllö wôrld', Encoding::UTF8, 'héllö wôrld'),
     ];
   }
 
@@ -178,3 +131,4 @@ final class Utf8TransformTest extends PHPUnit_Framework_TestCase {
   }
 
 }
+

--- a/tests/utf8/Utf8TransformTest.php
+++ b/tests/utf8/Utf8TransformTest.php
@@ -13,7 +13,7 @@ use function Facebook\FBExpect\expect;
 use type HH\Lib\Experimental\Str\Encoding;
 // @oss-disable: use InvariantViolationException as InvariantException;
 
-final class Utf8TransformTest extends PHPUnit_Framework_TestCase {
+final class Utf8TransformTest extends \Facebook\HackTest\HackTestCase {
 
   public static function provideLowercase(): varray<mixed> {
     return varray[

--- a/tests/utf8/Utf8TransformTest.php
+++ b/tests/utf8/Utf8TransformTest.php
@@ -15,8 +15,8 @@ use type HH\Lib\Experimental\Str\Encoding;
 
 final class Utf8TransformTest extends \Facebook\HackTest\HackTestCase {
 
-  public static function provideLowercase(): varray<mixed> {
-    return varray[
+  public static function provideLowercase(): vec<(string, string)> {
+    return vec[
       tuple('', ''),
       tuple('hello world', 'hello world'),
       tuple('Hello World', 'hello world'),
@@ -30,8 +30,8 @@ final class Utf8TransformTest extends \Facebook\HackTest\HackTestCase {
     expect(Utf8\lowercase($string))->toBeSame($expected);
   }
 
-  public static function provideUppercase(): varray<mixed> {
-    return varray[
+  public static function provideUppercase(): vec<(string, string)> {
+    return vec[
       tuple('', ''),
       tuple('hello world', 'HELLO WORLD'),
       tuple('Hello World', 'HELLO WORLD'),
@@ -45,8 +45,9 @@ final class Utf8TransformTest extends \Facebook\HackTest\HackTestCase {
     expect(Utf8\uppercase($string))->toBeSame($expected);
   }
 
-  public static function provideSplice(): varray<mixed> {
-    return varray[
+  public static function provideSplice(
+  ): vec<(string, string, int, ?int, string)> {
+    return vec[
       tuple('', '', 0, null, ''),
       tuple('héllö wôrld', 'darkness', 6, null, 'héllö darkness'),
       tuple('héllö wôrld', ' crüel ', 5, 1, 'héllö crüel wôrld'),
@@ -132,3 +133,4 @@ final class Utf8TransformTest extends \Facebook\HackTest\HackTestCase {
   }
 
 }
+


### PR DESCRIPTION
## Purpose

Add mb_* string functions to HSL to handle multi-byte strings. We use these quite a lot, especially `mb_strlen` and `mb_strpos`.

## Decisions Made
- Mirror `HH\Lib\Str` function signatures and names
- Be opinionated about encoding, supporting only UTF-8. Do not rely on `mb_internal_encoding`
- Use a sub-namespace of `HH\Lib\Str`, thinking that we'll also add other subnamespaces like `Grapheme` in another PR
- Do not duplicate `Str\` functions into this namespace which do not count bytes or characters, like `contains` and `join` and `ends_with`. Only functions where the distinction between a byte and a multi-byte character matters are implemented differently here. Perhaps even if we eventually move `Str\length` into `Str\Byte\length`, we'll want to keep the functions whose behavior doesn't depend on the interpretation of length/character count in the `Str` namespace?
- Don't implement every mb_* string function, just the ones we find most useful. The most obscure one in this list is probably `convert_kana`, we find it very useful to normalize half-width and full-width Kana for comparing Japanese strings
- `is_valid` replicates a check we occasionally do to test if a string is UTF-8
- Add an enum listing encodings, and support converting from those encodings to UTF-8, or from UTF-8 to those encodings. This is a trimmed down list of everything I got from `mb_list_encodings()`, cross referenced with wikipedia to get a list of commonly used encodings. I would be happy to trim this down more or add more encodings, I don't have strong opinions about this list.


Hoping to get feedback on the overall approach here. Once we agree on the namespaces and general set of functionality, I'll add unit tests to this PR.