### PR TITLE
Also add .hhconfig to gitattributes export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 tests/ export-ignore
+.hhconfig export-ignore


### PR DESCRIPTION
This means that when a release is installed, projects don't have
vendor/facebook/hsl-experiemental/.hhconfig, which can confuse IDE
integrations.