### PR TITLE
 add `HH\Lib\Experimental\Dict\union`

### DIFF
--- a/src/dict/combine.php
+++ b/src/dict/combine.php
@@ -7,7 +7,7 @@
  *  LICENSE file in the root directory of this source tree.
  *
  */
-namespace HH\Eexperimental\Lib\Dict;
+namespace HH\Lib\Experimental\Dict;
 
 use namespace HH\Lib\C;
 

--- a/src/dict/combine.php
+++ b/src/dict/combine.php
@@ -1,0 +1,30 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+namespace HH\Eexperimental\Lib\Dict;
+
+use namespace HH\Lib\C;
+
+/*
+ * Merge multiple KeyedTraversables into a new dict. In the case of duplicate
+ * keys, the value will be ignored.
+ */
+function union<Tk as arraykey, Tv>(
+  KeyedTraversable<Tk, Tv> ...$traversables
+): dict<Tk, Tv> {
+  $result = dict[];
+  foreach ($traversables as $traversable) {
+    foreach ($traversable as $key => $value) {
+        if (!C\contains_key($result, $key)) {
+            $result[$key] = $value;
+        }
+    }
+  }
+  return $result;
+}

--- a/tests/Dict/DictCombineTest.php
+++ b/tests/Dict/DictCombineTest.php
@@ -34,7 +34,7 @@ final class DictCombineTest extends HackTest {
       ),
       tuple(
         vec[
-          darray['c' => 'chocolat']
+          darray['c' => 'chocolat'], 
           dict['a' => 'pear', 'b' => 'strawberry', 'c' => 'cherry'],
           Map {'a' => 'apple', 'b' => 'banana'},
         ],
@@ -46,7 +46,7 @@ final class DictCombineTest extends HackTest {
   <<DataProvider('provideTestUnion')>>
   public function testUnion<Tk as arraykey, Tv>(
     Container<KeyedTraversable<Tk, Tv>> $traversables,
-    dict<Tk, Tv> $exprected
+    dict<Tk, Tv> $expected
   ): void {
     expect(Dict\union(...$traversables))->toBeSame($expected); 
   }

--- a/tests/Dict/DictCombineTest.php
+++ b/tests/Dict/DictCombineTest.php
@@ -1,0 +1,53 @@
+
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+use namespace HH\Lib\Experimental\Dict;
+use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\{DataProvider, HackTest}; // @oss-enable
+
+// @oss-disable: <<Oncalls('hack')>>
+final class DictCombineTest extends HackTest {
+  public static function provideTestUnion(): varray<mixed> {
+    return varray[
+      tuple(
+        vec[
+          Map {'a' => 'apple', 'b' => 'banana'},
+          dict['a' => 'pear', 'b' => 'strawberry', 'c' => 'cherry'],
+          darray['c' => 'chocolat']
+        ],
+        dict['a' => 'apple', 'b' => 'banana', 'c' => 'cherry']
+      ),
+      tuple(
+        vec[
+          dict['a' => 'pear', 'b' => 'strawberry', 'c' => 'cherry'],
+          Map {'a' => 'apple', 'b' => 'banana'},
+          darray['c' => 'chocolat']
+        ],
+        dict['a' => 'pear', 'b' => 'strawberry', 'c' => 'cherry']
+      ),
+      tuple(
+        vec[
+          darray['c' => 'chocolat']
+          dict['a' => 'pear', 'b' => 'strawberry', 'c' => 'cherry'],
+          Map {'a' => 'apple', 'b' => 'banana'},
+        ],
+        dict['c' => 'chocolat', 'a' => 'pear', 'b' => 'strawberry']
+      ),
+    ];
+  }
+  
+  <<DataProvider('provideTestUnion')>>
+  public function testUnion<Tk as arraykey, Tv>(
+    Container<KeyedTraversable<Tk, Tv>> $traversables,
+    dict<Tk, Tv> $exprected
+  ): void {
+    expect(Dict\union(...$traversables))->toBeSame($expected); 
+  }
+}

--- a/tests/Dict/DictCombineTest.php
+++ b/tests/Dict/DictCombineTest.php
@@ -1,4 +1,3 @@
-
 <?hh // strict
 /*
  *  Copyright (c) 2004-present, Facebook, Inc.


### PR DESCRIPTION
see : hhvm/hsl#68

just like PHPs `+` operator on arrays, this functions allows appending `KeyedTraversable`s into a new dict without overriding the values in case of duplicated keys unlike `HH\Lib\Dict\merge`.

reference : https://secure.php.net/manual/en/language.operators.array.php

example : 

```hack
<?hh

use namespace HH\Lib\Dict;

$a = dict[
    'a' => 'apple',
    'b' => 'banana'
];

$b = dict[
    'a' => 'pear', 
    'b' => 'strawberry', 
    'c' => 'cherry'
];

$c = Dict\merge($a, $b);
// $c = dict['a' => 'pear', 'b' => 'strawberry', 'c' => 'cherry'];

/* $d = $a + $b; */
$d = Dict\union($a, $b);
// $d = dict[ 'a' => 'apple', 'b' => 'banana', 'c' => 'cherry' ];
```