### PR TITLE
Use server_{input,output} for request input/output in CLI mode

### DIFF
--- a/src/io/stdio.php
+++ b/src/io/stdio.php
@@ -45,7 +45,15 @@ function server_input(): ReadHandle {
  *
  * @see requestOutput
  */
+<<__Memoize>>
 function request_output(): WriteHandle {
+  // php://input has differing eof behavior for interactive stdin - we need
+  // the php://stdin for interactive usage (e.g. repls)
+  /* HH_IGNORE_ERROR[2049] __PHPStdLib */
+  /* HH_IGNORE_ERROR[4107] __PHPStdLib */
+  if (\php_sapi_name() === "cli") {
+    return server_output();
+  }
   return _Private\StdioHandle::requestOutput();
 }
 
@@ -66,6 +74,14 @@ function request_error(): WriteHandle {
  * In CLI mode, this is likely STDIN; for HTTP requests, it may contain the
  * POST data, if any.
  */
+<<__Memoize>>
 function request_input(): ReadHandle {
+  // php://input has differing eof behavior for interactive stdin - we need
+  // the php://stdin for interactive usage (e.g. repls)
+  /* HH_IGNORE_ERROR[2049] __PHPStdLib */
+  /* HH_IGNORE_ERROR[4107] __PHPStdLib */
+  if (\php_sapi_name() === "cli") {
+    return server_input();
+  }
   return _Private\StdioHandle::requestInput();
 }


### PR DESCRIPTION
`php://input` is never a real file handle, even in CLI mode. We should
change this now we don't need to be PHP-compatible, but for now,
workaround it by exposing the real STDIN.

This demonstrates the diference:

```
<?php
$f = fopen('php://stdin', 'r');
stream_set_blocking($f, false);
fgets($f);
var_dump(feof($f)); // false for php://stdin, true for php://input
```

Test Plan:

- as above
- without this diff, hhast-lint (a.k.a. not-aurora) exits in CLI
  immediately after prompting "Woudl you like to apply this fix?", and IDE
  integration is completely broken (no lint errors appear). With this
  diff, both cases owrk fine