### PR TITLE
Updated open source testing

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,9 +1,22 @@
 #!/bin/sh
 set -ex
+apt update -y
+DEBIAN_FRONTEND=noninteractive apt install -y php-cli zip unzip
 hhvm --version
+php --version
+if [ ! -e .git/refs/heads/master ]; then
+  # - Travis clones with `--branch`, then moves to a detached HEAD state
+  # - if we're on a detached HEAD, Composer uses master to resolve branch
+  #   aliases.
+  # So, create the master branch :p
+  git branch master HEAD
+fi
 
+(
+  cd $(mktemp -d)
+  curl https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+)
 composer install
 
 hh_client
-
 hhvm vendor/bin/hacktest tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
-language: php
-php:
- - hhvm-nightly
+sudo: required
+language: generic
+services: docker
+env:
+ - HHVM_VERSION=latest
+ - HHVM_VERSION=nightly
+install:
+ - docker pull hhvm/hhvm:$HHVM_VERSION
 script:
- - ./.travis.sh
-notifications:
-  webhooks: https://code.facebook.com/travis/webhook/
+ - docker run --rm -w /var/source -v $(pwd):/var/source hhvm/hhvm:$HHVM_VERSION ./.travis.sh

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,18 @@
   "name": "hhvm/hsl-experimental",
   "description": "The Hack Standard Library - Experimental Additions",
   "license": "MIT",
+  "extra": {
+    "branch-alias": {
+      "dev-master": "4.x-dev"
+    }
+  },
   "require-dev": {
     "hhvm/hacktest": "^1.0",
-    "facebook/fbexpect": "^2.0"
+    "facebook/fbexpect": "^2.0",
+    "hhvm/hhvm-autoload": "^2.0"
   },
   "require": {
     "hhvm": "^4.0",
-    "hhvm/hhvm-autoload": "^2.0",
-    "hhvm/hsl": "dev-master"
+    "hhvm/hsl": "^4.0"
   }
 }


### PR DESCRIPTION
- add branch alias for master as 4.x, allowing dev dependencies on
  things that depend on hsl-experimental (e.g. hacktest -> hh-clilib ->
  HSL IO)
- dockerify testing