### PR TITLE
Add Duplex ( read + write ) handle interface

### DIFF
--- a/src/filesystem/FileHandle.php
+++ b/src/filesystem/FileHandle.php
@@ -12,7 +12,11 @@ namespace HH\Lib\Experimental\Filesystem;
 
 use namespace HH\Lib\{_Private, Experimental\IO};
 
-<<__Sealed(FileReadHandle::class, FileWriteHandle::class)>>
+<<__Sealed(
+  FileReadHandle::class,
+  FileWriteHandle::class,
+  FileDuplexHandle::class,
+)>>
 interface FileHandle extends IO\Handle {
   /**
    * Get the name of this file.
@@ -28,12 +32,12 @@ interface FileHandle extends IO\Handle {
   public function lock(FileLockType $mode): FileLock;
 }
 
-<<__Sealed(_Private\FileHandle::class, DisposableFileReadHandle::class)>>
+<<__Sealed(DisposableFileReadHandle::class, FileDuplexHandle::class)>>
 interface FileReadHandle extends FileHandle, IO\ReadHandle {
   public function seekForRead(int $offset): void;
 }
 
-<<__Sealed(_Private\FileHandle::class, DisposableFileWriteHandle::class)>>
+<<__Sealed(DisposableFileWriteHandle::class, FileDuplexHandle::class)>>
 interface FileWriteHandle extends FileHandle, IO\WriteHandle {
   /**
    * Move to a specific offset within a file.
@@ -44,17 +48,31 @@ interface FileWriteHandle extends FileHandle, IO\WriteHandle {
    * Any other pending operations (such as writes) will complete first.
    */
   public function seekForWriteAsync(int $offset): Awaitable<void>;
-
 }
 
-<<__Sealed(_Private\DisposableFileHandle::class)>>
+<<__Sealed(_Private\FileHandle::class, DisposableFileDuplexHandle::class)>>
+interface FileDuplexHandle
+  extends FileWriteHandle, FileReadHandle, IO\DuplexHandle {
+}
+
+<<__Sealed(DisposableFileDuplexHandle::class)>>
 interface DisposableFileReadHandle
   /* HH_FIXME[4194] non-disposable parent interface t34965102 */
   extends FileReadHandle, IO\DisposableReadHandle {
 }
 
-<<__Sealed(_Private\DisposableFileHandle::class)>>
+<<__Sealed(DisposableFileDuplexHandle::class)>>
 interface DisposableFileWriteHandle
   /* HH_FIXME[4194] non-disposable parent interface t34965102 */
   extends FileWriteHandle, IO\DisposableWriteHandle {
+}
+
+<<__Sealed(_Private\DisposableFileHandle::class)>>
+interface DisposableFileDuplexHandle
+  extends
+    /* HH_FIXME[4194] non-disposable parent interface t34965102 */
+    FileDuplexHandle,
+    DisposableFileWriteHandle,
+    DisposableFileReadHandle,
+    IO\DisposableDuplexHandle {
 }

--- a/src/filesystem/_Private/DisposableFileHandle.php
+++ b/src/filesystem/_Private/DisposableFileHandle.php
@@ -15,9 +15,7 @@ use namespace HH\Lib\Experimental\Filesystem;
 <<__Sealed(TemporaryFile::class)>>
 class DisposableFileHandle
   extends DisposableHandleWrapper<FileHandle>
-  implements
-    Filesystem\DisposableFileReadHandle,
-    Filesystem\DisposableFileWriteHandle {
+  implements Filesystem\DisposableFileDuplexHandle {
 
   public function __construct(FileHandle $impl) {
     parent::__construct($impl);

--- a/src/filesystem/_Private/FileHandle.php
+++ b/src/filesystem/_Private/FileHandle.php
@@ -14,7 +14,7 @@ use namespace HH\Lib\Experimental\Filesystem;
 
 final class FileHandle
   extends NativeHandle
-  implements Filesystem\FileReadHandle, Filesystem\FileWriteHandle {
+  implements Filesystem\FileDuplexHandle {
 
   public function __construct(
     private string $filename,

--- a/src/io/DisposableDuplexHandle.php
+++ b/src/io/DisposableDuplexHandle.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\IO;
+
+use namespace HH\Lib\Experimental\Filesystem;
+
+/* HH_FIXME[4194] non-disposable parent interface t34965102 */
+interface DisposableDuplexHandle extends DuplexHandle, \IAsyncDisposable {
+}

--- a/src/io/DuplexHandle.php
+++ b/src/io/DuplexHandle.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\IO;
+
+/** 
+ * An interface for read and write handles.
+ */
+interface DuplexHandle extends WriteHandle, ReadHandle {
+}

--- a/src/io/Handle.php
+++ b/src/io/Handle.php
@@ -21,6 +21,7 @@ use namespace HH\Lib\Experimental\Filesystem;
   UserspaceHandle::class,
   ReadHandle::class,
   WriteHandle::class,
+  DuplexHandle::class,
 )>>
 interface Handle {
   public function isEndOfFile(): bool;

--- a/src/io/_Private/DisposableHandleWrapper.php
+++ b/src/io/_Private/DisposableHandleWrapper.php
@@ -13,8 +13,8 @@ namespace HH\Lib\_Private;
 use namespace HH\Lib\{Experimental\Filesystem, Experimental\IO, Str};
 
 <<__Sealed(DisposableFileHandle::class)>>
-class DisposableHandleWrapper<T as IO\ReadHandle as IO\WriteHandle>
-  implements IO\DisposableReadHandle, IO\DisposableWriteHandle {
+class DisposableHandleWrapper<T as IO\DuplexHandle>
+  implements IO\DisposableDuplexHandle {
 
   public function __construct(protected T $impl) {
   }
@@ -43,7 +43,9 @@ class DisposableHandleWrapper<T as IO\ReadHandle as IO\WriteHandle>
     return await $this->impl->readAsync($max_bytes);
   }
 
-  public async function readLineAsync(?int $max_bytes = null): Awaitable<string> {
+  public async function readLineAsync(
+    ?int $max_bytes = null,
+  ): Awaitable<string> {
     return await $this->impl->readLineAsync($max_bytes);
   }
 

--- a/src/io/_Private/NativeHandle.php
+++ b/src/io/_Private/NativeHandle.php
@@ -13,7 +13,7 @@ namespace HH\Lib\_Private;
 use namespace HH\Lib\{Experimental\IO, Str};
 
 <<__Sealed(FileHandle::class, PipeHandle::class, StdioHandle::class)>>
-abstract class NativeHandle implements IO\ReadHandle, IO\WriteHandle {
+abstract class NativeHandle implements IO\DuplexHandle {
   private bool $isAwaitable = true;
   protected function __construct(private resource $impl) {
     /* HH_IGNORE_ERROR[2049] __PHPStdLib */
@@ -36,9 +36,7 @@ abstract class NativeHandle implements IO\ReadHandle, IO\WriteHandle {
 
   final public function rawReadBlocking(?int $max_bytes = null): string {
     if ($max_bytes is int && $max_bytes < 0) {
-      throw new \InvalidArgumentException(
-        '$max_bytes must be null, or >= 0',
-      );
+      throw new \InvalidArgumentException('$max_bytes must be null, or >= 0');
     }
     if ($max_bytes === 0) {
       return '';
@@ -70,9 +68,7 @@ abstract class NativeHandle implements IO\ReadHandle, IO\WriteHandle {
     ?int $max_bytes = null,
   ): Awaitable<string> {
     if ($max_bytes is int && $max_bytes < 0) {
-      throw new \InvalidArgumentException(
-        '$max_bytes must be null, or >= 0',
-      );
+      throw new \InvalidArgumentException('$max_bytes must be null, or >= 0');
     }
 
     $data = '';
@@ -93,9 +89,7 @@ abstract class NativeHandle implements IO\ReadHandle, IO\WriteHandle {
     ?int $max_bytes = null,
   ): Awaitable<string> {
     if ($max_bytes is int && $max_bytes < 0) {
-      throw new \InvalidArgumentException(
-        '$max_bytes must be null, or >= 0',
-      );
+      throw new \InvalidArgumentException('$max_bytes must be null, or >= 0');
     }
 
     if ($max_bytes === null) {


### PR DESCRIPTION
Note: this PR doesn't bring any BC break changes. existing code type hinted against `*ReadHandle` and `*WriteHandle` should work fine as the `*DuplexHandle` extends them.