### PR TITLE
Check for end of file before awaiting

### DIFF
--- a/src/io/_Private/NativeHandle.php
+++ b/src/io/_Private/NativeHandle.php
@@ -56,6 +56,9 @@ abstract class NativeHandle implements IO\ReadHandle, IO\WriteHandle {
     if (!$this->isAwaitable) {
       return;
     }
+    if ($this->isEndOfFile()) {
+      return;
+    }
     try {
       /* HH_FIXME[2049] *not* PHP stdlib */
       /* HH_FIXME[4107] *not* PHP stdlib */


### PR DESCRIPTION
On Linux, awaiting for read on an EOF returns immediately; on Mac, it
never returns. This is a regression caused by the recent fix to not
specify invalid flags to `stream_await()` - the invalid flags made it
/always/ return immediately, hiding this bug.

Test Plan:

`tests/filesystem/FileTest.php` freezes forever on mac without this
change; it passes with it.