### PR TITLE
Adding a Ref<T> class to the HSL.

### DIFF
--- a/src/util/IRef.php
+++ b/src/util/IRef.php
@@ -12,7 +12,7 @@ namespace HH\Lib\Util;
 
 /**
  * A replacement for PHP style references.
- * If your project already defined a Ref class,
+ * If your project already defines a Ref class,
  * you may implement this interface so both HH\Lib\Ref<T>
  * and Your\Project\Ref<T> would typecheck.
  */

--- a/src/util/IRef.php
+++ b/src/util/IRef.php
@@ -17,7 +17,6 @@ namespace HH\Lib\Util;
  * and Your\Project\Ref<T> would typecheck.
  */
 interface IRef<T> {
-  public function __construct(T $value);
   public function getValue(): T;
   public function setValue(T $value): T;
 }

--- a/src/util/IRef.php
+++ b/src/util/IRef.php
@@ -1,0 +1,23 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Util;
+
+/**
+ * A replacement for PHP style references.
+ * If your project already defined a Ref class,
+ * you may implement this interface so both HH\Lib\Ref<T>
+ * and Your\Project\Ref<T> would typecheck.
+ */
+interface IRef<T> {
+  public function __construct(T $value);
+  public function getValue(): T;
+  public function setValue(T $value): T;
+}

--- a/src/util/Ref.php
+++ b/src/util/Ref.php
@@ -16,11 +16,8 @@ namespace HH\Lib\Util;
  * It is recommended to use HH\Lib\Util\IRef<T> for type declarations.
  * Doing so allows your code to be flexible if a non HH\Lib Ref class
  * were to be introduced in your codebase.
- *
- * Extending this class is not recommended, however we understand that
- * this may be easier during the transition away from your own Ref<T> type.
  */
-class Ref<T> implements IRef<T> {
+final class Ref<T> implements IRef<T> {
   public function __construct(public T $value) {}
   public function getValue(): T {
     return $this->value;

--- a/src/util/Ref.php
+++ b/src/util/Ref.php
@@ -1,0 +1,31 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Util;
+
+/**
+ * A replacement for PHP style references.
+ *
+ * It is recommended to use HH\Lib\Util\IRef<T> for type declarations.
+ * Doing so allows your code to be flexible if a non HH\Lib Ref class
+ * were to be introduced in your codebase.
+ *
+ * Extending this class is not recommended, however we understand that
+ * this may be easier during the transition away from your own Ref<T> type.
+ */
+class Ref<T> implements IRef<T> {
+  public function __construct(public T $value) {}
+  public function getValue(): T {
+    return $this->value;
+  }
+  public function setValue(T $value): T {
+    return $this->value = $value;
+  }
+}

--- a/src/util/WrappedRef.php
+++ b/src/util/WrappedRef.php
@@ -12,13 +12,16 @@ namespace HH\Lib\Util;
 
 /**
  * A replacement for PHP style references.
- *
- * A bridge between a the HSL `IRef<T>`
- * and a similar class that does not implement `IRef<T>`.
+ * A bridge between a the HSL `IRef<T>` and a non-conforming Ref<T>`.
  * 
  * When dealing with another project that does not implement `IRef<T>`,
  * you might still need to use their project-bound `Ref<T>`.
  * This class acts like `IRef<T>` where T is the internal T from the other Ref.
+ *
+ * Reading and writing the new values using the provided callbacks ensures that:
+ * - all updates you make using `setValue()` and `getValue()` will be propagated.
+ * - all modifications to the project-bound Ref<T> will be transparently
+ *   read from within WrappedRef<T> by using `getValue()`.
  *
  * THIS DOES PREVENT THE GARBAGE COLLECTOR FROM DELETING THE UNDERLYING
  * PROJECT-BOUND REF<T> IF YOU ARE STILL HOLDING A REFERENCE TO IT.

--- a/src/util/WrappedRef.php
+++ b/src/util/WrappedRef.php
@@ -1,0 +1,50 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Util;
+
+/**
+ * A replacement for PHP style references.
+ *
+ * A bridge between a the HSL `IRef<T>`
+ * and a similar class that does not implement `IRef<T>`.
+ * 
+ * When dealing with another project that does not implement `IRef<T>`,
+ * you might still need to use their project-bound `Ref<T>`.
+ * This class acts like `IRef<T>` where T is the internal T from the other Ref.
+ *
+ * THIS DOES PREVENT THE GARBAGE COLLECTOR FROM DELETING THE UNDERLYING
+ * PROJECT-BOUND REF<T> IF YOU ARE STILL HOLDING A REFERENCE TO IT.
+ * IF YOU ARE ON HHVM3.30 OR LOWER AND THE PROJECT-BOUND REF<T> HAS A
+ * __DESTRUCT METHOD, YOU'LL CHANGE THE BEHAVIOR OF THE PROGRAM.
+ */
+final class WrappedRef<T> implements IRef<T> {
+  /**
+   * @param dynamic $wrapped The project bound `Ref<T>`
+   * @param (function(mixed): T) $read a callback for reading the value
+   * @param (function(mixed, T): T) $write a callback for writing the value
+   *
+   * Please note that there is no typesafety on interactions with $wrapped.
+   * You will be required to use `HH_FIXME[4110] when returning from $read.
+   */
+  public function __construct(
+    private dynamic $wrapped,
+    private (function(dynamic): T) $read,
+    private (function(dynamic, T): T) $write,
+  ) {}
+  public function getValue(): T {
+    $read = $this->read;
+    return $read($this->wrapped);
+  }
+  public function setValue(T $value): T {
+    $write = $this->write;
+    return $write($this->wrapped, $value);
+  }
+}

--- a/tests/util/RefTest.php
+++ b/tests/util/RefTest.php
@@ -1,0 +1,57 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use namespace HH\Lib\Util;
+use type Facebook\HackTest\DataProvider; // @oss-enable
+use function Facebook\FBExpect\expect; // @oss-enable
+// @oss-disable: use InvariantViolationException as InvariantException;
+
+final class RefTest extends \Facebook\HackTest\HackTest {
+
+  public function provideRef(): vec<(Util\Ref<int>)> {
+    return vec[tuple(new Util\Ref(3))];
+  }
+
+  public function testRefConstructorAssigns(): void {
+    $ref = new Util\Ref(3);
+    expect($ref->value)->toBeSame(
+      3,
+      'The constructor does not assign the first argument to Ref::value!',
+    );
+  }
+
+  <<DataProvider('provideRef')>>
+  public function testSetValueSetsValue(Util\Ref<int> $ref): void {
+    $ref->setValue(4);
+    expect($ref->value)->toBeSame(
+      4,
+      'Ref::setValue() does not assign the first argument to Ref::value!',
+    );
+  }
+
+  <<DataProvider('provideRef')>>
+  public function testGetValueGetsValue(Util\Ref<int> $ref): void {
+    expect($ref->getValue())->toBeSame(
+      $ref->value,
+      'Ref::getValue() does not return Ref::value!',
+    );
+  }
+
+  <<DataProvider('provideRef')>>
+  public function testSetValueReturnsTheAssignedValue(
+    Util\Ref<int> $ref,
+  ): void {
+    expect($ref->setValue(4))->toBeSame(
+      4,
+      'Ref::setValue() does not return the first argument to Ref::setValue()',
+    );
+  }
+
+}

--- a/tests/util/WrappedRefTest.php
+++ b/tests/util/WrappedRefTest.php
@@ -1,0 +1,123 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use namespace HH\Lib\Util;
+use namespace HH\Lib\Util\_Private;
+use type Facebook\HackTest\DataProvider; // @oss-enable
+use function Facebook\FBExpect\expect; // @oss-enable
+// @oss-disable: use InvariantViolationException as InvariantException;
+
+final class WrappedRefTest extends \Facebook\HackTest\HackTest {
+
+  public static function nineWarning(
+    _Private\ProjectBoundRef<int> $project,
+  ): void {
+    expect($project->v)->toNotBeSame(
+      9,
+      'This test must modify the value to 9, so you can not have the value set to 9 here',
+    );
+  }
+
+  public static function getProjectBoundRef(
+    int $value,
+  ): _Private\ProjectBoundRef<int> {
+    return new _Private\ProjectBoundRef($value);
+  }
+
+  public static function modifyWrappedRef<T>(
+    Util\IRef<T> $ref,
+    T $value,
+  ): void {
+    $ref->setValue($value);
+  }
+
+  public static function modifyProjectBoundRef<T>(
+    _Private\ProjectBoundRef<T> $ref,
+    T $value,
+  ): void {
+    $ref->v = $value;
+  }
+
+  public function provideWrappedRef(
+  ): vec<(Util\IRef<int>, _Private\ProjectBoundRef<int>)> {
+    $project = self::getProjectBoundRef(3);
+    return vec[tuple(
+      new Util\WrappedRef(
+        $project,
+        $ref ==> /*HH_FIXME[4110] dynamic to T implicit cast*/$ref->v,
+        ($ref, $value) ==> $ref->v = $value,
+      ),
+      $project,
+    )];
+  }
+
+  public function testRefConstructorAdoptsValue(): void {
+    $wrapped = new Util\WrappedRef(
+      self::getProjectBoundRef(3),
+      $ref ==> /*HH_FIXME[4110]*/$ref->v,
+      ($ref, $value) ==> $ref->v = $value,
+    );
+    expect($wrapped->getValue())->toBeSame(
+      3,
+      'The constructor does not adopt the value from _Private\ProjectBoundRef<T>!',
+    );
+  }
+
+  <<DataProvider('provideWrappedRef')>>
+  public function testGetValueReadsTheValueFromProjectBoundRef(
+    Util\IRef<int> $ref,
+    _Private\ProjectBoundRef<int> $project,
+  ): void {
+    expect($ref->getValue())->toBeSame(
+      $project->v,
+      'WrappedRef::getValue() does not return the value of $project->v!',
+    );
+  }
+
+  <<DataProvider('provideWrappedRef')>>
+  public function testSetValueReturnsTheAssignedValue(
+    Util\IRef<int> $ref,
+    _Private\ProjectBoundRef<int> $project,
+  ): void {
+    self::nineWarning($project);
+    expect($ref->setValue(9))->toBeSame(
+      9,
+      'WrappedRef::setValue() does not return the first argument to WrappedRef::setValue()',
+    );
+  }
+
+  <<DataProvider('provideWrappedRef')>>
+  public function testModifyingTheProjectBoundRefInADifferentScope(
+    Util\IRef<int> $ref,
+    _Private\ProjectBoundRef<int> $project,
+  ): void {
+    self::nineWarning($project);
+    self::modifyProjectBoundRef($project, 9);
+    expect($project->v)->toBeSame(
+      $ref->getValue(),
+      'Modifying the $project->v in a different scope should update $ref->getValue()',
+    );
+    expect($project->v)->toBeSame(9, 'Helper method failure!');
+  }
+
+  <<DataProvider('provideWrappedRef')>>
+  public function testModifyingTheWrappedRefInADifferentScope(
+    Util\IRef<int> $ref,
+    _Private\ProjectBoundRef<int> $project,
+  ): void {
+    self::nineWarning($project);
+    self::modifyWrappedRef($ref, 9);
+    expect($project->v)->toBeSame(
+      $ref->getValue(),
+      'Modifying the WrappedRef<T> in a different scope should update $project->v',
+    );
+    expect($ref->getValue())->toBeSame(9, 'Helper method failure!');
+  }
+}

--- a/tests/util/_Private.php
+++ b/tests/util/_Private.php
@@ -1,0 +1,20 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Util\_Private;
+
+/**
+ * This class belongs to WrappedRefTest.
+ * It is meant to closely mimic the HHVM-team's Ref<T>,
+ * but it may stand in for any implementation.
+ */
+final class ProjectBoundRef<T> {
+  public function __construct(public T $v) {}
+}


### PR DESCRIPTION
Currently hack projects define their own implementation of `Ref<T>`, in order to use reference semantics through objects. This makes working with `Ref<T>` classes from other projects cumbersome on the typechecker. I propose `Ref<T>` and `IRef<T>` to be introduced under `HH\Lib\Util`.

*Why `IRef<T>`?*
Since some projects might have a hard time stamping out their own project-bound `Ref<T>` class, they may make their own `Ref<T>` class implement `IRef<T>` to gain interoperability with all other projects. By updating the type declarations to `IRef<T>` on properties, parameters, returns, and generic types, the project-bound `Ref<T>` and the HSL's `Ref<T>` could be used interchangeably. (Provided that their Ref::setValue() was not a void function. If it was, the implementation will need to be updated to remain compatible.)

*Why is `Ref<T>` final?*
We should not encourage projects to migrate to the HSL's `Ref<T>` by extending the class. This will lead to useless error messages if for whatever reason a second non-HSL `Ref<T>` type was introduced or if a HSL `Ref<T>` was used in a project-bound `Ref<T>` context. By forcing projects to implement `IRef<T>` in order to get interoperability, we ensure that every project will be equally compatible.