### PR TITLE
Release Async\Poll, Async\Semaphore, Async\Condition and friends

### DIFF
--- a/src/async/BasePoll.php
+++ b/src/async/BasePoll.php
@@ -1,0 +1,163 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\Async;
+
+/**
+ * Asynchronous equivalent of mechanisms such as epoll(), poll() and select().
+ *
+ * Transforms a set of Awaitables to an asynchronous iterator that produces
+ * results of these Awaitables as soon as they are ready. The order of results
+ * is not guaranteed in any way. New Awaitables can be added to the Poll
+ * while it is being iterated.
+ *
+ * This mechanism has two primary use cases:
+ *
+ * 1. Speculatively issuing non-CPU-intensive requests to different backends
+ *    with very high processing latency, waiting for the first satisfying
+ *    result and ignoring all remaining requests.
+ *
+ *    Example: cross-DC memcache requests
+ *
+ * 2. Processing relatively small number of high level results in the order
+ *    of completion and flushing the output to the user.
+ *
+ *    Example: pagelets, multiple GraphQL queries, streamable GraphQL queries
+ *
+ * ===== WARNING ===== WARNING ===== WARNING ===== WARNING ===== WARNING =====
+ *
+ * This is a very heavy-weight mechanism with non-trivial CPU cost. NEVER use
+ * this in the following situations:
+ *
+ * 1. Waiting for the first available result and ignoring the rest of work,
+ *    unless the processing latency is extremely high (10ms or more) and
+ *    the CPU cost of ignored work is negligible. Note: the ignored work
+ *    will still be computed and will delay your processing anyway if it's
+ *    CPU costly.
+ *
+ * 2. Reordering huge amount of intermediary results. This is currently known
+ *    to be CPU-intensive.
+ *
+ * ===== WARNING ===== WARNING ===== WARNING ===== WARNING ===== WARNING =====
+ */
+
+<<__ConsistentConstruct>>
+abstract class BasePoll<Tk, Tv> {
+  final public static function create(): this {
+    return new static();
+  }
+
+  final protected static function fromImpl(
+    KeyedTraversable<Tk, Awaitable<Tv>> $awaitables,
+  ): this {
+    $poll = new static();
+    $poll->addMultiImpl($awaitables);
+    return $poll;
+  }
+
+  private ?ConditionNode<(Tk, Tv)> $lastAdded;
+  private ?ConditionNode<(Tk, Tv)> $lastNotified;
+  private ?ConditionNode<(Tk, Tv)> $lastAwaited;
+  private Awaitable<void> $notifiers;
+
+  private function __construct() {
+    $head = new ConditionNode();
+    $this->lastAdded = $head;
+    $this->lastNotified = $head;
+    $this->lastAwaited = $head;
+    $this->notifiers = async {
+    };
+  }
+
+  final protected function addImpl(Tk $key, Awaitable<Tv> $awaitable): void {
+    invariant(
+      $this->lastAdded !== null,
+      'Unable to add item, iteration already finished',
+    );
+
+    // Create condition node representing pending event.
+    $this->lastAdded = $this->lastAdded->addNext();
+
+    // Make sure the next pending condition is notified upon completion.
+    $awaitable = $this->waitForThenNotify($key, $awaitable);
+
+    // Keep track of all pending events.
+    $this->notifiers = AwaitAllWaitHandle::fromVec(
+      vec[$awaitable, $this->notifiers],
+    );
+  }
+
+  final protected function addMultiImpl(
+    KeyedTraversable<Tk, Awaitable<Tv>> $awaitables,
+  ): void {
+    invariant(
+      $this->lastAdded !== null,
+      'Unable to add item, iteration already finished',
+    );
+    $last_added = $this->lastAdded;
+
+    // Initialize new list of notifiers.
+    $notifiers = vec[$this->notifiers];
+
+    foreach ($awaitables as $key => $awaitable) {
+      // Create condition node representing pending event.
+      $last_added = $last_added->addNext();
+
+      // Make sure the next pending condition is notified upon completion.
+      $awaitable = $this->waitForThenNotify($key, $awaitable);
+      $notifiers[] = $awaitable;
+    }
+
+    // Keep track of all pending events.
+    $this->lastAdded = $last_added;
+    $this->notifiers = AwaitAllWaitHandle::fromVec($notifiers);
+  }
+
+  private async function waitForThenNotify(
+    Tk $key,
+    Awaitable<Tv> $awaitable,
+  ): Awaitable<void> {
+    try {
+      $result = await $awaitable;
+      $this->lastNotified = ($this->lastNotified as nonnull)->getNext() as
+        nonnull;
+      $this->lastNotified->succeed(tuple($key, $result));
+    } catch (\Exception $exception) {
+      $this->lastNotified = ($this->lastNotified as nonnull)->getNext() as
+        nonnull;
+      $this->lastNotified->fail($exception);
+    }
+  }
+
+  final public async function next(): Awaitable<?(Tk, Tv)> {
+    invariant(
+      $this->lastAwaited !== null,
+      'Unable to iterate, iteration already finished',
+    );
+
+    $this->lastAwaited = $this->lastAwaited->getNext();
+    if ($this->lastAwaited === null) {
+      // End of iteration, no pending events to await.
+      $this->lastAdded = null;
+      $this->lastNotified = null;
+      return null;
+    }
+
+    return await $this->lastAwaited->waitForNotificationAsync($this->notifiers);
+  }
+
+  final public function hasNext(): bool {
+    invariant(
+      $this->lastAwaited !== null,
+      'Unable to iterate, iteration already finished',
+    );
+    return $this->lastAwaited->getNext() !== null;
+  }
+}

--- a/src/async/Condition.php
+++ b/src/async/Condition.php
@@ -1,0 +1,74 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\Async;
+
+/**
+ * A wrapper around ConditionWaitHandle that allows notification events
+ * to occur before the condition is awaited.
+ */
+class Condition<T> {
+  private ?Awaitable<T> $condition = null;
+
+  /**
+   * Notify the condition variable of success and set the result.
+   */
+  final public function succeed(T $result): void {
+    if ($this->condition === null) {
+      $this->condition = async {
+        return $result;
+      };
+    } else {
+      invariant(
+        $this->condition is ConditionWaitHandle<_>,
+        'Unable to notify AsyncCondition twice',
+      );
+      /* HH_FIXME[4110]: Type error revealed by type-safe instanceof feature. See https://fburl.com/instanceof */
+      $this->condition->succeed($result);
+    }
+  }
+
+  /**
+   * Notify the condition variable of failure and set the exception.
+   */
+  final public function fail(\Exception $exception): void {
+    if ($this->condition === null) {
+      $this->condition = async {
+        throw $exception;
+      };
+    } else {
+      invariant(
+        $this->condition is ConditionWaitHandle<_>,
+        'Unable to notify AsyncCondition twice',
+      );
+      $this->condition->fail($exception);
+    }
+  }
+
+  /**
+   * Asynchronously wait for the condition variable to be notified and
+   * return the result or throw the exception received via notification.
+   *
+   * The caller must provide an Awaitable $notifiers (which must be a
+   * WaitHandle) that must not finish before the notification is received.
+   * This means $notifiers must represent work that is guaranteed to
+   * eventually trigger the notification. As long as the notification is
+   * issued only once, asynchronous execution unrelated to $notifiers is
+   * allowed to trigger the notification.
+   */
+  final public async function waitForNotificationAsync(
+    Awaitable<void> $notifiers,
+  ): Awaitable<T> {
+    if ($this->condition === null) {
+      $this->condition = ConditionWaitHandle::create($notifiers);
+    }
+    return await $this->condition;
+  }
+}

--- a/src/async/ConditionNode.php
+++ b/src/async/ConditionNode.php
@@ -1,0 +1,28 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\Async;
+
+/**
+ * A linked list node storing Condition and pointer to the next node.
+ */
+final class ConditionNode<T> extends Condition<T> {
+  private ?ConditionNode<T> $next = null;
+
+  public function addNext(): ConditionNode<T> {
+    invariant($this->next === null, 'The next node already exists');
+    $this->next = new ConditionNode();
+    return $this->next;
+  }
+
+  public function getNext(): ?ConditionNode<T> {
+    return $this->next;
+  }
+}

--- a/src/async/KeyedPoll.php
+++ b/src/async/KeyedPoll.php
@@ -1,0 +1,39 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\Async;
+
+/**
+ * ===== WARNING ===== WARNING ===== WARNING ===== WARNING ===== WARNING =====
+ *
+ * See detailed warning for `BasePoll`
+ *
+ * ===== WARNING ===== WARNING ===== WARNING ===== WARNING ===== WARNING =====
+ */
+final class KeyedPoll<Tk, Tv>
+  extends BasePoll<Tk, Tv>
+  implements AsyncKeyedIterator<Tk, Tv> {
+
+  public static function from(
+    KeyedTraversable<Tk, Awaitable<Tv>> $awaitables,
+  ): this {
+    return self::fromImpl($awaitables);
+  }
+
+  public function add(Tk $key, Awaitable<Tv> $awaitable): void {
+    $this->addImpl($key, $awaitable);
+  }
+
+  public function addMulti(
+    KeyedTraversable<Tk, Awaitable<Tv>> $awaitables,
+  ): void {
+    $this->addMultiImpl($awaitables);
+  }
+}

--- a/src/async/Poll.php
+++ b/src/async/Poll.php
@@ -1,0 +1,34 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\Async;
+
+/**
+ * ===== WARNING ===== WARNING ===== WARNING ===== WARNING ===== WARNING =====
+ *
+ * See detailed warning at top of `BasePoll`
+ *
+ * ===== WARNING ===== WARNING ===== WARNING ===== WARNING ===== WARNING =====
+ */
+
+final class Poll<Tv> extends BasePoll<mixed, Tv> implements AsyncIterator<Tv> {
+
+  public static function from(Traversable<Awaitable<Tv>> $awaitables): this {
+    return self::fromImpl(new Vector($awaitables));
+  }
+
+  public function add(Awaitable<Tv> $awaitable): void {
+    $this->addImpl(null, $awaitable);
+  }
+
+  public function addMulti(Traversable<Awaitable<Tv>> $awaitables): void {
+    $this->addMultiImpl(new Vector($awaitables));
+  }
+}

--- a/src/async/Semaphore.php
+++ b/src/async/Semaphore.php
@@ -1,0 +1,75 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\Async;
+
+use namespace HH\Lib\C;
+
+final class Semaphore<Tin, Tout> {
+
+  private static int $uniqueIDCounter = 0;
+  private dict<int, Condition<null>> $blocking = dict[];
+  private ?Awaitable<void> $activeGen;
+  private int $runningCount = 0;
+  private int $recentOpenCount = 0;
+
+  public function __construct(
+    private int $concurrentLimit,
+    private (function(Tin): Awaitable<Tout>) $f,
+  ) {
+    invariant($concurrentLimit > 0, "Concurrent limit must be greater than 0.");
+  }
+
+  public async function waitForAsync(Tin $value): Awaitable<Tout> {
+    $gen = async {
+      if (
+        $this->runningCount + $this->recentOpenCount >= $this->concurrentLimit
+      ) {
+        $unique_id = self::$uniqueIDCounter;
+        self::$uniqueIDCounter++;
+        $condition = new Condition();
+        $this->blocking[$unique_id] = $condition;
+        await $condition->waitForNotificationAsync(async {
+          await $this->activeGen;
+        });
+        invariant(
+          $this->recentOpenCount > 0,
+          'Expecting at least one recentOpenCount.',
+        );
+        $this->recentOpenCount--;
+      }
+      invariant(
+        $this->runningCount < $this->concurrentLimit,
+        'Expecting open run slot',
+      );
+      $f = $this->f;
+      $this->runningCount++;
+      try {
+        return await $f($value);
+      } finally {
+        $this->runningCount--;
+        $next_blocked_id = C\first_key($this->blocking);
+        if ($next_blocked_id !== null) {
+          $next_blocked = $this->blocking[$next_blocked_id];
+          unset($this->blocking[$next_blocked_id]);
+          $this->recentOpenCount++;
+          $next_blocked->succeed(null);
+        }
+      }
+    };
+    /* HH_FIXME[4110]: the types of $this->activeGen and $gen are both ruined
+                       by being unified when passing them to fromVec */
+    $this->activeGen ??= async {};
+    $this->activeGen = AwaitAllWaitHandle::fromVec(vec[$this->activeGen, $gen]);
+    /* HH_FIXME[4110]: the types of $this->activeGen and $gen are both ruined
+                       by being unified when passing them to fromVec */
+    return await $gen;
+  }
+}

--- a/src/private.php
+++ b/src/private.php
@@ -53,3 +53,12 @@ final class PHPErrorLogger implements \IDisposable {
     \set_error_handler($this->oldHandler);
   }
 }
+
+/**
+ * Stop eager execution of an async function.
+ *
+ * ==== ONLY USE THIS IN HSL IMPLEMENTATION AND TESTS ===
+ */
+function stop_eager_execution(): RescheduleWaitHandle {
+  return RescheduleWaitHandle::create(RescheduleWaitHandle::QUEUE_DEFAULT, 0);
+}

--- a/tests/async/ConditionTest.php
+++ b/tests/async/ConditionTest.php
@@ -1,0 +1,66 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use namespace HH\Lib\Experimental\Async;
+
+use function Facebook\FBExpect\expect; // @oss-enable
+use type Facebook\HackTest\HackTest; // @oss-enable
+// @oss-disable: use type HackTest;
+use function HH\Lib\_Private\stop_eager_execution;
+
+// @oss-disable: <<Oncalls('hphp_hphpi'), InterestedIndividuals('jan')>>
+final class ConditionTest extends HackTest {
+
+  public async function testSucceedFirst(): Awaitable<void> {
+    $condition = new Async\Condition();
+    $condition->succeed(42);
+    $result = await $condition->waitForNotificationAsync(async {
+    });
+    expect($result)->toBePHPEqual(42);
+  }
+
+  public async function testFailFirst(): Awaitable<void> {
+    $condition = new Async\Condition();
+    $condition->fail(new Exception('hello world'));
+    try {
+      $result = await $condition->waitForNotificationAsync(async {
+      });
+      throw new Exception('expected to fail');
+    } catch (Exception $e) {
+      expect($e->getMessage())->toBePHPEqual('hello world');
+    }
+  }
+
+  public async function testSucceedLater(): Awaitable<void> {
+    $condition = new Async\Condition();
+    $worker = async {
+      await stop_eager_execution();
+      $condition->succeed(42);
+    };
+
+    $result = await $condition->waitForNotificationAsync($worker);
+    expect($result)->toBePHPEqual(42);
+  }
+
+  public async function testFailLater(): Awaitable<void> {
+    $condition = new Async\Condition();
+    $worker = async {
+      await stop_eager_execution();
+      $condition->fail(new Exception('hello world'));
+    };
+
+    try {
+      $result = await $condition->waitForNotificationAsync($worker);
+      throw new Exception('expected to fail');
+    } catch (Exception $e) {
+      expect($e->getMessage())->toBePHPEqual('hello world');
+    }
+  }
+}

--- a/tests/async/PollTest.php
+++ b/tests/async/PollTest.php
@@ -1,0 +1,133 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use namespace HH\Lib\Experimental\Async;
+
+use function Facebook\FBExpect\expect; // @oss-enable
+use type Facebook\HackTest\{DataProvider, HackTest}; // @oss-enable
+// @oss-disable: use type HackTest;
+
+// @oss-disable: <<Oncalls('hphp_hphpi'), InterestedIndividuals('jan')>>
+final class PollTest extends HackTest {
+  public async function testEmpty(): Awaitable<void> {
+    foreach (Async\Poll::create() await as $value) {
+      throw new Exception('expected to be empty');
+    }
+  }
+
+  public async function testEmptyKeyed(): Awaitable<void> {
+    foreach (Async\KeyedPoll::create() await as $value) {
+      throw new Exception('expected to be empty');
+    }
+  }
+
+  public static function provideTestInputs(
+  ): varray<(varray<Awaitable<int>>, varray<int>, bool)> {
+    $block = async (int $prio) ==> await RescheduleWaitHandle::create(0, $prio);
+
+    return varray[
+      // Empty
+      tuple(
+        varray[],
+        varray[],
+        false,
+      ),
+      // One eager success
+      tuple(
+        varray[async { return 42; }],
+        varray[42],
+        false,
+      ),
+      // One resumed success
+      tuple(
+        varray[async { await $block(0); return 42; }],
+        varray[42],
+        false,
+      ),
+      // One eager failure
+      tuple(
+        varray[async { throw new Exception(); }],
+        varray[],
+        true,
+      ),
+      // One resumed failure
+      tuple(
+        varray[async { await $block(0); throw new Exception(); }],
+        varray[],
+        true,
+      ),
+      // Combination
+      tuple(
+        varray[
+          async { return 1; },
+          async { await $block(1); return 2; },
+          async { return 3; },
+          async { await $block(3); return 4; },
+          async { await $block(2); throw new Exception(); },
+          async { await $block(0); return 5; },
+          async { return 6; },
+        ],
+        varray[1, 3, 6, 5, 2],
+        true,
+      ),
+    ];
+  }
+
+  <<DataProvider('provideTestInputs')>>
+  public async function testInputs(
+    varray<Awaitable<int>> $awaitables,
+    varray<int> $expected_results,
+    bool $expected_exception,
+  ): Awaitable<void> {
+    $results = varray[];
+    $exception = false;
+    try {
+      foreach (Async\Poll::from($awaitables) await as $value) {
+        $results[] = $value;
+      }
+    } catch (Exception $e) {
+      if (!$expected_exception) {
+        throw $e;
+      }
+      $exception = true;
+    }
+
+    expect($results)->toBeSame($expected_results);
+    expect($exception)->toBeSame($expected_exception);
+  }
+
+  public async function testKeyed(): Awaitable<void> {
+    $poll = Async\KeyedPoll::from(darray[
+      'k1' => async {
+        return 1;
+      },
+    ]);
+    $poll->add('k2', async { return 2; });
+    $count = 0;
+    foreach($poll await as $key => $value) {
+      $count += 1;
+      switch ($key) {
+        case 'k1':
+          expect($value)->toBePHPEqual(1);
+          break;
+        case 'k2':
+          expect($value)->toBePHPEqual(2);
+          $poll->addMulti(darray['k3' => async { return 3; }]);
+          break;
+        case 'k3':
+          expect($value)->toBePHPEqual(3);
+          break;
+        default:
+          invariant_violation("unexpected key: %s", $key);
+      }
+    }
+    expect($count)->toBePHPEqual(3);
+  }
+}

--- a/tests/async/SemaphoreTest.php
+++ b/tests/async/SemaphoreTest.php
@@ -1,0 +1,156 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use namespace HH\Lib\Vec;
+use namespace HH\Lib\Experimental\Async;
+use type HH\Lib\_Private\Ref;
+
+use function Facebook\FBExpect\expect; // @oss-enable
+use type Facebook\HackTest\HackTest; // @oss-enable
+// @oss-disable: use type HackTest;
+use function HH\Lib\_Private\stop_eager_execution;
+
+// @oss-disable: <<
+  // @oss-disable: Oncalls('hphp_hphpi'),
+  // @oss-disable: InterestedIndividuals('jan', 'kendallhopkins')
+// @oss-disable: >>
+final class SemaphoreTest extends HackTest {
+
+  const float TIME_DELTA = 1.;
+  const int USLEEP_BLOCK = 500000;
+  const float SLEEP_BLOCK = self::USLEEP_BLOCK / 1000000.;
+
+  public async function testLimitConcurrencySimpleAsync(): Awaitable<void> {
+    $semaphore = new Async\Semaphore(10, async ($i) ==> {
+      await HH\Asio\usleep(self::USLEEP_BLOCK);
+      return $i;
+    });
+    /* HH_IGNORE_ERROR[4107] PHP stdlib */
+    /* HH_IGNORE_ERROR[2049] PHP stdlib */
+    $start = microtime(true);
+    $results = await Vec\map_async(
+      Vec\range(0, 99),
+      async $i ==> await $semaphore->waitForAsync($i),
+    );
+    /* HH_IGNORE_ERROR[4107] PHP stdlib */
+    /* HH_IGNORE_ERROR[2049] PHP stdlib */
+    $end = microtime(true);
+    expect($end - $start)->toEqualWithDelta(self::SLEEP_BLOCK * 10, self::TIME_DELTA);
+    expect($results)->toBeSame(Vec\range(0, 99));
+  }
+
+  public async function testLimitConcurrencyFastAsync(): Awaitable<void> {
+    $semaphore = new Async\Semaphore(10, async ($i) ==> $i);
+    $results = await Vec\map_async(
+      Vec\range(0, 99),
+      async $i ==> await $semaphore->waitForAsync($i),
+    );
+    expect($results)->toBeSame(Vec\range(0, 99));
+  }
+
+  public async function testConcurrencyLimiterExceptionAsync(): Awaitable<void> {
+    $semaphore = new Async\Semaphore(10, async ($_) ==> {
+      await HH\Asio\usleep(self::USLEEP_BLOCK);
+      throw new \Exception();
+    });
+    /* HH_IGNORE_ERROR[4107] PHP stdlib */
+    /* HH_IGNORE_ERROR[2049] PHP stdlib */
+    $start = microtime(true);
+    await Vec\map_async(
+      Vec\range(0, 99),
+      async $_ ==> await HH\Asio\wrap($semaphore->waitForAsync(42)),
+    );
+    /* HH_IGNORE_ERROR[4107] PHP stdlib */
+    /* HH_IGNORE_ERROR[2049] PHP stdlib */
+    $end = microtime(true);
+    expect($end - $start)->toEqualWithDelta(self::SLEEP_BLOCK * 10, self::TIME_DELTA);
+  }
+
+  public async function testConcurrencyLimiterSingleAsync(): Awaitable<void> {
+    $checker = new Ref(false);
+    $semaphore = new Async\Semaphore(1, async ($i) ==> {
+      expect($checker->value)
+        ->toBeFalse('Found two running at the same time');
+      $checker->value = true;
+      await HH\Asio\usleep(self::USLEEP_BLOCK);
+      expect($checker->value)->toBeTrue();
+      $checker->value = false;
+      return $i;
+    });
+
+    /* HH_IGNORE_ERROR[4107] PHP stdlib */
+    /* HH_IGNORE_ERROR[2049] PHP stdlib */
+    $start = microtime(true);
+    $results = await Vec\map_async(
+      Vec\range(0, 9),
+      async $i ==> await $semaphore->waitForAsync($i),
+    );
+    /* HH_IGNORE_ERROR[4107] PHP stdlib */
+    /* HH_IGNORE_ERROR[2049] PHP stdlib */
+    $end = microtime(true);
+    expect($checker->value)->toBeFalse();
+    expect($end - $start)->toEqualWithDelta(self::SLEEP_BLOCK * 10, self::TIME_DELTA);
+    expect($results)->toBeSame(Vec\range(0, 9));
+  }
+
+  public async function testExtreme1(): Awaitable<void> {
+    $semaphore = new Async\Semaphore(1, async ($i) ==> $i);
+    /* HH_IGNORE_ERROR[4107] PHP stdlib */
+    /* HH_IGNORE_ERROR[2049] PHP stdlib */
+    $start = microtime(true);
+    $results = await Vec\map_async(
+      Vec\range(0, 9999),
+      async $i ==> await $semaphore->waitForAsync($i),
+    );
+    /* HH_IGNORE_ERROR[4107] PHP stdlib */
+    /* HH_IGNORE_ERROR[2049] PHP stdlib */
+    $end = microtime(true);
+    expect($end - $start)->toEqualWithDelta(0., self::TIME_DELTA);
+    expect($results)->toBeSame(Vec\range(0, 9999));
+  }
+
+  public async function testExtreme2(): Awaitable<void> {
+    $semaphore = new Async\Semaphore(10000, async ($i) ==> {
+      await HH\Asio\usleep(self::USLEEP_BLOCK);
+      return $i;
+    });
+    /* HH_IGNORE_ERROR[4107] PHP stdlib */
+    /* HH_IGNORE_ERROR[2049] PHP stdlib */
+    $start = microtime(true);
+    $results = await Vec\map_async(
+      Vec\range(0, 9999),
+      async $i ==> await $semaphore->waitForAsync($i),
+    );
+    /* HH_IGNORE_ERROR[4107] PHP stdlib */
+    /* HH_IGNORE_ERROR[2049] PHP stdlib */
+    $end = microtime(true);
+    expect($end - $start)->toEqualWithDelta(self::SLEEP_BLOCK, self::TIME_DELTA);
+    expect($results)->toBeSame(Vec\range(0, 9999));
+  }
+
+  public async function testExtreme3(): Awaitable<void> {
+    $semaphore = new Async\Semaphore(1, async ($i) ==> {
+      await stop_eager_execution();
+      return $i;
+    });
+    /* HH_IGNORE_ERROR[4107] PHP stdlib */
+    /* HH_IGNORE_ERROR[2049] PHP stdlib */
+    $start = microtime(true);
+    $results = await Vec\map_async(
+      Vec\range(0, 9999),
+      async $i ==> await $semaphore->waitForAsync($i),
+    );
+    /* HH_IGNORE_ERROR[4107] PHP stdlib */
+    /* HH_IGNORE_ERROR[2049] PHP stdlib */
+    $end = microtime(true);
+    expect($end - $start)->toEqualWithDelta(0., self::TIME_DELTA);
+    expect($results)->toBeSame(Vec\range(0, 9999));
+  }
+}


### PR DESCRIPTION
Summary:
- HHAST already has a private copy of `Async\Condition`, `Async\Poll` etc for
  coordinating LSP (IDE) responses
- It has a poor reimplementation of `Async\Semaphore` as `ConcurrentAsyncQueue`
- I also need either `Async\Semaphore` or `Vec\fb\gen_map_limit_concurrency`
  in hacktest to allow tests to run in parallel
- Even if `Vec\fb\gen_map_limit_concurrency` is used in `hacktest`, I need
  `Async\Semaphore` in docs.hhvm.com to allow me to keep using the DataProvider
  abstraction and spawn hh_parse a bunch of times without forkbombing CI.

Differential Revision: D15283462

