### PR TITLE
Update requirement from 4.0 to 4.1, test on 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ sudo: required
 language: generic
 services: docker
 env:
+ - HHVM_VERSION=4.1-latest
  - HHVM_VERSION=latest
  - HHVM_VERSION=nightly
 matrix:
   allow_failures:
+    - env: HHVM_VERSION=4.1-latest
     - env: HHVM_VERSION=latest
 install:
  - docker pull hhvm/hhvm:$HHVM_VERSION

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "hhvm/hhvm-autoload": "^2.0"
   },
   "require": {
-    "hhvm": "^4.0",
+    "hhvm": "^4.1",
     "hhvm/hsl": "^4.0"
   }
 }


### PR DESCRIPTION
- 4.0 is unsupported
- add CI job for 4.1 - so we test on min release, latest release, and
nightlies