### PR TITLE
Update HSL requirement to v4.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
   },
   "require": {
     "hhvm": "^4.1",
-    "hhvm/hsl": "^4.0"
+    "hhvm/hsl": "^4.7"
   }
 }


### PR DESCRIPTION
`HH\Lib\_Private\Ref<T>` is now `HH\Lib\Ref<T>`, and is used by
hsl-experimental; we need an HSL version that is newer than that change