### PR TITLE
Implement `Vec\is_sorted` and `Vec\is_sorted_by`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
 - HHVM_VERSION=nightly
 matrix:
   allow_failures:
-  - env: HHVM_VERSION=4.3-latest
   - env: HHVM_VERSION=latest
 install:
 - docker pull hhvm/hhvm:$HHVM_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.8-latest
+- HHVM_VERSION=4.13-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.3-latest
+- HHVM_VERSION=4.8-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "hhvm/hhvm-autoload": "^2.0"
   },
   "require": {
-    "hhvm": "^4.8",
+    "hhvm": "^4.13",
     "hhvm/hsl": "^4.7"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "hhvm/hhvm-autoload": "^2.0"
   },
   "require": {
-    "hhvm": "^4.3",
+    "hhvm": "^4.8",
     "hhvm/hsl": "^4.7"
   }
 }

--- a/src/vec/introspect.php
+++ b/src/vec/introspect.php
@@ -1,0 +1,70 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Vec;
+
+use namespace HH\Lib\C;
+
+/**
+ * Returns true if the given `Container<num>` is sorted using strict weak ordering.
+ * Sort order is ascending.
+ *
+ * Time complexity: O(n), where `n` is the size of $c
+ * Space complexity: O(1)
+ */
+<<__Rx, __ProvenanceSkipFrame>>
+function is_sorted(Container<num> $c): bool {
+	if (C\is_empty($c)) {
+		return true;
+	}
+
+	$laggard = C\firstx($c);
+	foreach ($c as $val) {
+		if ($val < $laggard) {
+			return false;
+		}
+		$laggard = $val;
+	}
+
+	return true;
+}
+
+/**
+ * Returns true if the given `Container<T>` is sorted according to the supplied
+ * $spaceship_func.
+ * Sort order is ascending.
+ *
+ * A spaceship function must return:
+ *  - A positve integer is the first argument is greater than the second
+ *  - A negative integer is the first argument is lesser than the second
+ *  - Zero if both arguments are equal
+ *
+ * Time complexity: O(n), where `n` is the size of $c
+ * Space complexity: O(1)
+ */
+<<__Rx, __AtMostRxAsArgs, __ProvenanceSkipFrame>>
+function is_sorted_by<T>(
+	Container<T> $c,
+	<<__AtMostRxAsFunc>> (function(T, T): int) $spaceship_func,
+): bool {
+	if (C\is_empty($c)) {
+		return true;
+	}
+
+	$laggard = C\firstx($c);
+	foreach ($c as $val) {
+		if ($spaceship_func($laggard, $val) > 0) {
+			return false;
+		}
+		$laggard = $val;
+	}
+
+	return true;
+}

--- a/tests/vec/VecTest.php
+++ b/tests/vec/VecTest.php
@@ -1,0 +1,105 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use namespace HH\Lib\{Str, Vec};
+
+use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\{DataProvider, HackTest};
+
+/** 
+ * This is basic coverage of Vec\is_sorted and Vec\is_sorted_by
+ */
+final class VecTest extends HackTest {
+
+  public function provideStableStrictOrdered(): vec<(Container<num>, bool)> {
+    return vec[
+      tuple(vec[], true),
+      tuple(vec[0], true),
+      tuple(vec[0, 1], true),
+      tuple(vec[0, 1, 5, 10], true),
+      tuple(vec[-5, 0, 5], true),
+      tuple(vec[0, 2, 1], false),
+      tuple(vec[-5, 0, -5], false),
+    ];
+  }
+
+  <<DataProvider('provideStableStrictOrdered')>>
+  public function testStableStrictOrdering(
+    Container<num> $c,
+    bool $result,
+  ): void {
+    expect(Vec\is_sorted($c))->toBeSame($result);
+  }
+
+  public function provideStableWeakOrdered(): vec<(Container<num>, bool)> {
+    return vec[
+      tuple(vec[0, 0], true),
+      tuple(vec[0, 1, 1], true),
+      tuple(vec[-5, -4, -4, -4, -1, 3, 3, 5], true),
+      tuple(vec[-5, -4, -4, -4, -1, 3, 2, 5], false),
+    ];
+  }
+
+  <<DataProvider('provideStableWeakOrdered')>>
+  public function testStableWeakOrdering(
+    Container<num> $c,
+    bool $result,
+  ): void {
+    expect(Vec\is_sorted($c))->toBeSame($result);
+  }
+
+  public function provideStableStrictOrderedUsingBy(
+  ): vec<(Container<string>, (function(string, string): int), bool)> {
+    $strlen_shaceship = (string $a, string $b) ==>
+      Str\length($a) <=> Str\length($b);
+
+    return vec[
+      tuple(vec[], ($_, $_) ==> -1, true),
+      tuple(vec[], ($_, $_) ==> 1, true),
+      tuple(vec[''], $strlen_shaceship, true),
+      tuple(vec['', 'a'], $strlen_shaceship, true),
+      tuple(vec['', 'a', 'aaa', 'aaaaa'], $strlen_shaceship, true),
+      tuple(vec['', 'a', 'aaaaaa', 'aaaaa'], $strlen_shaceship, false),
+    ];
+  }
+
+  <<DataProvider('provideStableStrictOrderedUsingBy')>>
+  public function testStableStrictOrderingUsingBy<T>(
+    Container<T> $c,
+    (function(T, T): int) $spaceship_func,
+    bool $result,
+  ): void {
+    expect(Vec\is_sorted_by($c, $spaceship_func))->toBeSame($result);
+  }
+
+
+  public function provideWeakStrictOrderedUsingBy(
+  ): vec<(Container<string>, (function(string, string): int), bool)> {
+    $strlen_shaceship = (string $a, string $b) ==>
+      Str\length($a) <=> Str\length($b);
+
+    return vec[
+      tuple(vec['a', 'a'], $strlen_shaceship, true),
+      tuple(vec['aa', 'aaa', 'aaa'], $strlen_shaceship, true),
+      tuple(vec['a', 'aa', 'aa', 'aa', 'aaa', 'aaa'], $strlen_shaceship, true),
+      tuple(vec['aa', 'aa', 'aaaa', 'aaa', 'aaa'], $strlen_shaceship, false),
+    ];
+  }
+
+  <<DataProvider('provideWeakStrictOrderedUsingBy')>>
+  public function testWeakStrictOrderingUsingBy<T>(
+    Container<T> $c,
+    (function(T, T): int) $spaceship_func,
+    bool $result,
+  ): void {
+    expect(Vec\is_sorted_by($c, $spaceship_func))->toBeSame($result);
+  }
+
+}


### PR DESCRIPTION
I was very much torn on how to name this function and where to put it.
This could have been 
- `C\is_sorted` in C/introspect.php
- `C\is_sorted` in C/order.php
- `Vec\is_sorted` in Vec/introspect.php
- `Vec\is_sorted` in Vec/order.php

Putting it in `C` would require a `C\is_sorted_with_key` and `C\is_sorted_with_key_by`, which felt rather long for the HSL.
Putting it in `Vec` would reduce the name to `Dict\is_sorted` and `Dict\is_sorted_by`. Although, the naming is a bit misleading, since your can put non-dicts and non-vecs in these functions.

I would love to hear some feedback on the naming. A good name makes a function discoverable.