### PR TITLE
Update requirements to 4.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.3-latest
+- HHVM_VERSION=4.10-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 matrix:
   allow_failures:
-  - env: HHVM_VERSION=4.3-latest
+  - env: HHVM_VERSION=4.10-latest
   - env: HHVM_VERSION=latest
 install:
 - docker pull hhvm/hhvm:$HHVM_VERSION

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "hhvm/hhvm-autoload": "^2.0"
   },
   "require": {
-    "hhvm": "^4.3",
-    "hhvm/hsl": "^4.7"
+    "hhvm": "^4.10",
+    "hhvm/hsl": "^4.10"
   }
 }


### PR DESCRIPTION
Might as well match what the HSL currently requires.

Need HSL 4.10 to get the error suppresison disposable.