### PR TITLE
rfc: remove 'File' from class/interface names in the `File\` namespaces

### DIFF
--- a/src/file/DisposableReadHandle.php
+++ b/src/file/DisposableReadHandle.php
@@ -11,5 +11,5 @@
 namespace HH\Lib\Experimental\File;
 
 /* HH_FIXME[4194] disposable extending non-disposable interface */
-interface DisposableFileWriteHandle extends \IAsyncDisposable, FileWriteHandle {
+interface DisposableReadHandle extends \IAsyncDisposable, ReadHandle {
 }

--- a/src/file/DisposableReadWriteHandle.php
+++ b/src/file/DisposableReadWriteHandle.php
@@ -10,11 +10,6 @@
 
 namespace HH\Lib\Experimental\File;
 
-use namespace HH\Lib\_Private;
-use namespace HH\Lib\Experimental\IO;
-
-final class NonDisposableFileWriteHandle
-  extends _Private\NonDisposableFileHandle
-  implements FileWriteHandle, IO\NonDisposableWriteHandle {
-  use _Private\LegacyPHPResourceWriteHandleTrait;
+/* HH_FIXME[4194] disposable extending non-disposable interface */
+interface DisposableReadWriteHandle extends \IAsyncDisposable, ReadWriteHandle, DisposableReadHandle, DisposableWriteHandle {
 }

--- a/src/file/DisposableWriteHandle.php
+++ b/src/file/DisposableWriteHandle.php
@@ -10,8 +10,6 @@
 
 namespace HH\Lib\Experimental\File;
 
-use namespace HH\Lib\_Private;
-
 /* HH_FIXME[4194] disposable extending non-disposable interface */
-interface DisposableFileReadWriteHandle extends \IAsyncDisposable, FileReadWriteHandle, DisposableFileReadHandle, DisposableFileWriteHandle {
+interface DisposableWriteHandle extends \IAsyncDisposable, WriteHandle {
 }

--- a/src/file/Handle.php
+++ b/src/file/Handle.php
@@ -15,10 +15,10 @@ use namespace HH\Lib\{_Private, Experimental\IO};
 <<__Sealed(
   _Private\DisposableFileHandle::class,
   _Private\NonDisposableFileHandle::class,
-  FileReadHandle::class,
-  FileWriteHandle::class,
+  ReadHandle::class,
+  WriteHandle::class,
 )>>
-interface FileHandle extends IO\Handle {
+interface Handle extends IO\Handle {
   /**
    * Get the name of this file.
    */
@@ -40,29 +40,29 @@ interface FileHandle extends IO\Handle {
   public function seekAsync(int $offset): Awaitable<void>;
 
   <<__ReturnDisposable>>
-  public function lock(FileLockType $mode): FileLock;
+  public function lock(LockType $mode): Lock;
 }
 
 <<__Sealed(
-  DisposableFileReadHandle::class,
-  FileReadWriteHandle::class,
-  NonDisposableFileReadHandle::class,
+  DisposableReadHandle::class,
+  ReadWriteHandle::class,
+  NonDisposableReadHandle::class,
 )>>
-interface FileReadHandle extends FileHandle, IO\ReadHandle {
+interface ReadHandle extends Handle, IO\ReadHandle {
 }
 
 <<__Sealed(
-  DisposableFileWriteHandle::class,
-  FileReadWriteHandle::class,
-  NonDisposableFileWriteHandle::class,
+  DisposableWriteHandle::class,
+  ReadWriteHandle::class,
+  NonDisposableWriteHandle::class,
 )>>
-interface FileWriteHandle extends FileHandle, IO\WriteHandle {
+interface WriteHandle extends Handle, IO\WriteHandle {
 }
 
 <<__Sealed(
-  NonDisposableFileReadWriteHandle::class,
-  DisposableFileReadWriteHandle::class,
+  NonDisposableReadWriteHandle::class,
+  DisposableReadWriteHandle::class,
 )>>
-interface FileReadWriteHandle
-  extends FileWriteHandle, FileReadHandle, IO\ReadWriteHandle {
+interface ReadWriteHandle
+  extends WriteHandle, ReadHandle, IO\ReadWriteHandle {
 }

--- a/src/file/Lock.php
+++ b/src/file/Lock.php
@@ -14,18 +14,18 @@ use namespace HH\Lib\{_Private, Experimental\IO};
 
 /**
  * A File Lock, which is unlocked as a disposable. To acquire one, call `lock`
- * on a FileBase object.
+ * on a Base object.
  *
  * Note that in some cases, such as the non-blocking lock types, we may throw
- * an `FileLockAcquisitionException` instead of acquiring the lock. If this
+ * an `LockAcquisitionException` instead of acquiring the lock. If this
  * is not desired behavior it should be guarded against.
  */
-final class FileLock implements \IDisposable {
+final class Lock implements \IDisposable {
   private resource $resource;
 
   public function __construct(
-    <<__AcceptDisposable>> FileHandle $handle,
-    FileLockType $lock_type,
+    <<__AcceptDisposable>> Handle $handle,
+    LockType $lock_type,
   ) {
     $this->resource =
       /* HH_IGNORE_ERROR[4179] doing dodgy things to disposables */
@@ -36,7 +36,7 @@ final class FileLock implements \IDisposable {
     /* HH_IGNORE_ERROR[4107] __PHPStdLib */
     $flock_result = \flock($this->resource, $lock_type, inout $_wouldblock);
     if (!$flock_result) {
-      throw new FileLockAcquisitionException();
+      throw new LockAcquisitionException();
     }
   }
 

--- a/src/file/LockType.php
+++ b/src/file/LockType.php
@@ -10,30 +10,30 @@
 
 namespace HH\Lib\Experimental\File;
 
-enum FileLockType: int as int {
+enum LockType: int as int {
   /**
    * Any number of processes may have a shared lock simultaneously. It is
-   * commonly called a reader lock. The creation of a FileLock will block until
+   * commonly called a reader lock. The creation of a Lock will block until
    * the lock is acquired.
    */
   SHARED = \LOCK_SH;
 
   /**
-   * Like a shared lock, but the creation of a FileLock will throw a
-   * `FileLockAcquisitionException` if the lock was not acquired instead of
+   * Like a shared lock, but the creation of a Lock will throw a
+   * `LockAcquisitionException` if the lock was not acquired instead of
    * blocking.
    */
   SHARED_NON_BLOCKING = \LOCK_SH | \LOCK_NB;
 
   /**
    * Only a single process may possess an exclusive lock to a given file at a
-   * time. The creation of a FileLock will block until the lock is acquired.
+   * time. The creation of a Lock will block until the lock is acquired.
    */
   EXCLUSIVE = \LOCK_EX;
 
   /**
-   * Like an exclusive lock, but the creation of a FileLock will throw a
-   * `FileLockAcquisitionException` if the lock was not acquired instead of
+   * Like an exclusive lock, but the creation of a Lock will throw a
+   * `LockAcquisitionException` if the lock was not acquired instead of
    * blocking.
    */
   EXCLUSIVE_NON_BLOCKING = \LOCK_EX | \LOCK_NB;

--- a/src/file/NonDisposableReadHandle.php
+++ b/src/file/NonDisposableReadHandle.php
@@ -10,6 +10,11 @@
 
 namespace HH\Lib\Experimental\File;
 
-/* HH_FIXME[4194] disposable extending non-disposable interface */
-interface DisposableFileReadHandle extends \IAsyncDisposable, FileReadHandle {
+use namespace HH\Lib\_Private;
+use namespace HH\Lib\Experimental\IO;
+
+final class NonDisposableReadHandle
+  extends _Private\NonDisposableFileHandle
+  implements ReadHandle, IO\NonDisposableReadHandle {
+  use _Private\LegacyPHPResourceReadHandleTrait;
 }

--- a/src/file/NonDisposableReadWriteHandle.php
+++ b/src/file/NonDisposableReadWriteHandle.php
@@ -13,8 +13,9 @@ namespace HH\Lib\Experimental\File;
 use namespace HH\Lib\_Private;
 use namespace HH\Lib\Experimental\IO;
 
-final class NonDisposableFileReadHandle
+final class NonDisposableReadWriteHandle
   extends _Private\NonDisposableFileHandle
-  implements FileReadHandle, IO\NonDisposableReadHandle {
+  implements ReadWriteHandle, IO\NonDisposableReadWriteHandle {
   use _Private\LegacyPHPResourceReadHandleTrait;
+  use _Private\LegacyPHPResourceWriteHandleTrait;
 }

--- a/src/file/NonDisposableWriteHandle.php
+++ b/src/file/NonDisposableWriteHandle.php
@@ -13,9 +13,8 @@ namespace HH\Lib\Experimental\File;
 use namespace HH\Lib\_Private;
 use namespace HH\Lib\Experimental\IO;
 
-final class NonDisposableFileReadWriteHandle
+final class NonDisposableWriteHandle
   extends _Private\NonDisposableFileHandle
-  implements FileReadWriteHandle, IO\NonDisposableReadWriteHandle {
-  use _Private\LegacyPHPResourceReadHandleTrait;
+  implements WriteHandle, IO\NonDisposableWriteHandle {
   use _Private\LegacyPHPResourceWriteHandleTrait;
 }

--- a/src/file/WriteMode.php
+++ b/src/file/WriteMode.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\Experimental\File;
 
-enum FileWriteMode: string {
+enum WriteMode: string {
   /**
    * Open the file for writing only; place the file pointer at the beginning of
    * the file.

--- a/src/file/_Private/DisposableFileHandle.php
+++ b/src/file/_Private/DisposableFileHandle.php
@@ -15,7 +15,7 @@ use namespace HH\Lib\Experimental\File;
 <<__ConsistentConstruct>>
 abstract class DisposableFileHandle<T as NonDisposableFileHandle>
   extends DisposableHandleWrapper<T>
-  implements File\FileHandle {
+  implements File\Handle {
   final public function __construct(T $impl) {
     parent::__construct($impl);
   }
@@ -30,8 +30,8 @@ abstract class DisposableFileHandle<T as NonDisposableFileHandle>
 
   <<__ReturnDisposable>>
   final public function lock(
-    File\FileLockType $type,
-  ): File\FileLock {
+    File\LockType $type,
+  ): File\Lock {
     return $this->impl->lock($type);
   }
 

--- a/src/file/_Private/DisposableFileReadHandle.php
+++ b/src/file/_Private/DisposableFileReadHandle.php
@@ -13,7 +13,7 @@ namespace HH\Lib\_Private;
 use namespace HH\Lib\Experimental\File;
 
 final class DisposableFileReadHandle
-  extends DisposableFileHandle<File\NonDisposableFileReadHandle>
-  implements File\DisposableFileReadHandle {
-  use DisposableReadHandleWrapperTrait<File\NonDisposableFileReadHandle>;
+  extends DisposableFileHandle<File\NonDisposableReadHandle>
+  implements File\DisposableReadHandle {
+  use DisposableReadHandleWrapperTrait<File\NonDisposableReadHandle>;
 }

--- a/src/file/_Private/DisposableFileReadWriteHandle.php
+++ b/src/file/_Private/DisposableFileReadWriteHandle.php
@@ -13,12 +13,12 @@ namespace HH\Lib\_Private;
 use namespace HH\Lib\Experimental\File;
 
 final class DisposableFileReadWriteHandle
-  extends DisposableFileHandle<File\NonDisposableFileReadWriteHandle>
-  implements File\DisposableFileReadWriteHandle {
+  extends DisposableFileHandle<File\NonDisposableReadWriteHandle>
+  implements File\DisposableReadWriteHandle {
   use DisposableReadHandleWrapperTrait<
-    File\NonDisposableFileReadWriteHandle,
+    File\NonDisposableReadWriteHandle,
   >;
   use DisposableWriteHandleWrapperTrait<
-    File\NonDisposableFileReadWriteHandle,
+    File\NonDisposableReadWriteHandle,
   >;
 }

--- a/src/file/_Private/DisposableFileWriteHandle.php
+++ b/src/file/_Private/DisposableFileWriteHandle.php
@@ -13,9 +13,9 @@ namespace HH\Lib\_Private;
 use namespace HH\Lib\Experimental\File;
 
 final class DisposableFileWriteHandle
-  extends DisposableFileHandle<File\NonDisposableFileWriteHandle>
-  implements File\DisposableFileWriteHandle {
+  extends DisposableFileHandle<File\NonDisposableWriteHandle>
+  implements File\DisposableWriteHandle {
   use DisposableWriteHandleWrapperTrait<
-    File\NonDisposableFileWriteHandle,
+    File\NonDisposableWriteHandle,
   >;
 }

--- a/src/file/_Private/NonDisposableFileHandle.php
+++ b/src/file/_Private/NonDisposableFileHandle.php
@@ -15,7 +15,7 @@ use namespace HH\Lib\Experimental\{IO, File};
 <<__ConsistentConstruct>>
 abstract class NonDisposableFileHandle
   extends LegacyPHPResourceHandle
-  implements File\FileHandle, IO\NonDisposableHandle {
+  implements File\Handle, IO\NonDisposableHandle {
   protected string $filename;
 
   final protected function __construct(string $path, string $mode) {
@@ -28,7 +28,7 @@ abstract class NonDisposableFileHandle
   /* HH_IGNORE_ERROR[4107] __PHPStdLib */
   $f = \fopen($path, $mode);
     if ($f === false) {
-      throw new File\FileOpenException(
+      throw new File\OpenException(
         'Failed to open file: '.$errors->getLastErrorx()['message'],
       );
     }
@@ -56,9 +56,9 @@ abstract class NonDisposableFileHandle
 
   <<__ReturnDisposable>>
   final public function lock(
-    File\FileLockType $type,
-  ): File\FileLock {
-    return new File\FileLock($this, $type);
+    File\LockType $type,
+  ): File\Lock {
+    return new File\Lock($this, $type);
   }
 
   final public async function seekAsync(int $offset): Awaitable<void> {

--- a/src/file/_Private/TemporaryFile.php
+++ b/src/file/_Private/TemporaryFile.php
@@ -13,13 +13,13 @@ namespace HH\Lib\_Private;
 use namespace HH\Lib\Experimental\{File, IO};
 
 final class TemporaryFile
-  extends DisposableFileHandle<File\NonDisposableFileReadWriteHandle>
-  implements File\DisposableFileReadWriteHandle {
+  extends DisposableFileHandle<File\NonDisposableReadWriteHandle>
+  implements File\DisposableReadWriteHandle {
   use DisposableReadHandleWrapperTrait<
-    File\NonDisposableFileReadWriteHandle,
+    File\NonDisposableReadWriteHandle,
   >;
   use DisposableWriteHandleWrapperTrait<
-    File\NonDisposableFileReadWriteHandle,
+    File\NonDisposableReadWriteHandle,
   >;
 
   public async function __disposeAsync(): Awaitable<void> {

--- a/src/file/exceptions.php
+++ b/src/file/exceptions.php
@@ -10,10 +10,10 @@
 
 namespace HH\Lib\Experimental\File;
 
-final class FileCreateException extends \Exception {}
-final class FileOpenException extends \Exception {}
+final class CreateException extends \Exception {}
+final class OpenException extends \Exception {}
 
 /**
  * An exception thrown when a file lock was not successfully acquired.
  */
-final class FileLockAcquisitionException extends \Exception {}
+final class LockAcquisitionException extends \Exception {}

--- a/src/file/open.php
+++ b/src/file/open.php
@@ -12,9 +12,9 @@ namespace HH\Lib\Experimental\File;
 
 use namespace HH\Lib\_Private;
 
-function open_read_only_nd(string $path): NonDisposableFileReadHandle {
+function open_read_only_nd(string $path): NonDisposableReadHandle {
   return
-    NonDisposableFileReadHandle::__createInstance_IMPLEMENTATION_DETAIL_DO_NOT_USE(
+    NonDisposableReadHandle::__createInstance_IMPLEMENTATION_DETAIL_DO_NOT_USE(
       $path,
       'rb',
     );
@@ -22,10 +22,10 @@ function open_read_only_nd(string $path): NonDisposableFileReadHandle {
 
 function open_write_only_nd(
   string $path,
-  FileWriteMode $mode = FileWriteMode::OPEN_OR_CREATE,
-): NonDisposableFileWriteHandle {
+  WriteMode $mode = WriteMode::OPEN_OR_CREATE,
+): NonDisposableWriteHandle {
   return
-    NonDisposableFileWriteHandle::__createInstance_IMPLEMENTATION_DETAIL_DO_NOT_USE(
+    NonDisposableWriteHandle::__createInstance_IMPLEMENTATION_DETAIL_DO_NOT_USE(
       $path,
       $mode as string,
     );
@@ -33,25 +33,25 @@ function open_write_only_nd(
 
 function open_read_write_nd(
   string $path,
-  FileWriteMode $mode = FileWriteMode::OPEN_OR_CREATE,
-): NonDisposableFileReadWriteHandle {
+  WriteMode $mode = WriteMode::OPEN_OR_CREATE,
+): NonDisposableReadWriteHandle {
   return
-    NonDisposableFileReadWriteHandle::__createInstance_IMPLEMENTATION_DETAIL_DO_NOT_USE(
+    NonDisposableReadWriteHandle::__createInstance_IMPLEMENTATION_DETAIL_DO_NOT_USE(
       $path,
       ($mode as string).'+',
     );
 }
 
 <<__ReturnDisposable>>
-function open_read_only(string $path): DisposableFileReadHandle {
+function open_read_only(string $path): DisposableReadHandle {
   return new _Private\DisposableFileReadHandle(open_read_only_nd($path));
 }
 
 <<__ReturnDisposable>>
 function open_write_only(
   string $path,
-  FileWriteMode $mode = FileWriteMode::OPEN_OR_CREATE,
-): DisposableFileWriteHandle {
+  WriteMode $mode = WriteMode::OPEN_OR_CREATE,
+): DisposableWriteHandle {
   return new _Private\DisposableFileWriteHandle(
     open_write_only_nd($path, $mode),
   );
@@ -60,8 +60,8 @@ function open_write_only(
 <<__ReturnDisposable>>
 function open_read_write(
   string $path,
-  FileWriteMode $mode = FileWriteMode::OPEN_OR_CREATE,
-): DisposableFileReadWriteHandle {
+  WriteMode $mode = WriteMode::OPEN_OR_CREATE,
+): DisposableReadWriteHandle {
   return new _Private\DisposableFileReadWriteHandle(
     open_read_write_nd($path, $mode),
   );

--- a/src/file/temporary_file.php
+++ b/src/file/temporary_file.php
@@ -13,11 +13,11 @@ namespace HH\Lib\Experimental\File;
 use namespace HH\Lib\_Private;
 
 <<__ReturnDisposable>>
-function temporary_file(): DisposableFileReadWriteHandle {
+function temporary_file(): DisposableReadWriteHandle {
   /* HH_IGNORE_ERROR[2049] PHP stdlib */
   /* HH_IGNORE_ERROR[4107] PHP stdlib */
   $path = \sys_get_temp_dir().'/'.\bin2hex(\random_bytes(8));
   return new _Private\TemporaryFile(
-    open_read_write_nd($path, FileWriteMode::MUST_CREATE),
+    open_read_write_nd($path, WriteMode::MUST_CREATE),
   );
 }

--- a/src/io/Handle.php
+++ b/src/io/Handle.php
@@ -18,7 +18,7 @@ use namespace HH\Lib\Experimental\File;
  * Order of operations is guaranteed.
  */
 <<__Sealed(
-  File\FileHandle::class,
+  File\Handle::class,
   NonDisposableHandle::class,
   ReadHandle::class,
   UserspaceHandle::class,

--- a/tests/file/FileTest.php
+++ b/tests/file/FileTest.php
@@ -24,15 +24,15 @@ final class FileTest extends HackTest {
     $filename = sys_get_temp_dir().'/'.bin2hex(random_bytes(16));
     $f1 = File\open_write_only_nd(
       $filename,
-      File\FileWriteMode::MUST_CREATE,
+      File\WriteMode::MUST_CREATE,
     );
     await $f1->writeAsync('Hello, world!');
     expect(async () ==> {
       await using File\open_write_only(
         $filename,
-        File\FileWriteMode::MUST_CREATE,
+        File\WriteMode::MUST_CREATE,
       );
-    })->toThrow(File\FileOpenException::class);
+    })->toThrow(File\OpenException::class);
     await $f1->closeAsync();
 
     await using $f2 = File\open_read_only($filename);
@@ -103,7 +103,7 @@ final class FileTest extends HackTest {
     expect(file_get_contents($path))->toEqual('Hello, world');
 
     await using (
-      $f = File\open_write_only($path, File\FileWriteMode::TRUNCATE)
+      $f = File\open_write_only($path, File\WriteMode::TRUNCATE)
     ) {
       await $f->writeAsync('Foo bar');
     }
@@ -118,7 +118,7 @@ final class FileTest extends HackTest {
 
     $path = $tf->getPath()->toString();
     await using (
-      $f = File\open_write_only($path, File\FileWriteMode::APPEND)
+      $f = File\open_write_only($path, File\WriteMode::APPEND)
     ) {
       await $f->writeAsync("\nGoodbye, cruel world");
     }


### PR DESCRIPTION
Summary:
namedebate

- it's shorter
- it was redundant
- expected usage is via `use namespace`, rather than `use type`
- downside: we have classes with the same name in the `IO\` and `File\` namespace

Differential Revision: D17672206

