### PR TITLE
Bare minimum TCP client support

### DIFF
--- a/src/io/Handle.php
+++ b/src/io/Handle.php
@@ -11,7 +11,7 @@
 namespace HH\Lib\Experimental\IO;
 
 use namespace HH\Lib\_Private;
-use namespace HH\Lib\Experimental\File;
+use namespace HH\Lib\Experimental\{File, Network};
 
 /** An interface for IO handles.
  *
@@ -19,6 +19,7 @@ use namespace HH\Lib\Experimental\File;
  */
 <<__Sealed(
   File\Handle::class,
+  Network\Socket::class,
   NonDisposableHandle::class,
   ReadHandle::class,
   UserspaceHandle::class,

--- a/src/network/IPProtocolBehavior.php
+++ b/src/network/IPProtocolBehavior.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\Network;
+
+enum IPProtocolBehavior: int {
+  PREFER_IPV6 = 0;
+  FORCE_IPV6 = 1;
+  FORCE_IPV4 = 2;
+}

--- a/src/network/Socket.php
+++ b/src/network/Socket.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\Network;
+
+use namespace HH\Lib\Experimental\{IO, TCP};
+
+<<__Sealed(TCP\Socket::class)>>
+interface Socket extends IO\Handle {
+}

--- a/src/tcp/DisposableSocket.php
+++ b/src/tcp/DisposableSocket.php
@@ -1,0 +1,19 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\TCP;
+
+use namespace HH\Lib\_Private;
+use namespace HH\Lib\Experimental\IO;
+
+<<__Sealed(_Private\DisposableTCPSocket::class)>>
+interface DisposableSocket
+  extends \IAsyncDisposable, IO\DisposableReadWriteHandle, Socket {
+}

--- a/src/tcp/NonDisposableSocket.php
+++ b/src/tcp/NonDisposableSocket.php
@@ -1,0 +1,18 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\TCP;
+
+use namespace HH\Lib\_Private;
+use namespace HH\Lib\Experimental\IO;
+
+<<__Sealed(_Private\NonDisposableTCPSocket::class)>>
+interface NonDisposableSocket extends Socket, IO\NonDisposableReadWriteHandle {
+}

--- a/src/tcp/Socket.php
+++ b/src/tcp/Socket.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\TCP;
+
+use namespace HH\Lib\Experimental\{IO, Network};
+
+<<__Sealed(DisposableSocket::class, NonDisposableSocket::class)>>
+interface Socket extends Network\Socket, IO\ReadWriteHandle {
+}

--- a/src/tcp/_Private/DisposableTCPSocket.php
+++ b/src/tcp/_Private/DisposableTCPSocket.php
@@ -1,0 +1,28 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\_Private;
+
+use namespace HH\Lib\Experimental\{IO, TCP};
+
+final class DisposableTCPSocket
+  extends DisposableHandleWrapper<TCP\NonDisposableSocket>
+  implements
+    \IAsyncDisposable,
+    IO\DisposableReadWriteHandle,
+    TCP\DisposableSocket {
+
+  use DisposableReadHandleWrapperTrait<TCP\NonDisposableSocket>;
+  use DisposableWriteHandleWrapperTrait<TCP\NonDisposableSocket>;
+
+  public function __construct(TCP\NonDisposableSocket $impl) {
+    parent::__construct($impl);
+  }
+}

--- a/src/tcp/_Private/NonDisposableTCPSocket.php
+++ b/src/tcp/_Private/NonDisposableTCPSocket.php
@@ -1,0 +1,24 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\_Private;
+
+use namespace HH\Lib\Experimental\{IO, TCP};
+
+final class NonDisposableTCPSocket
+  extends LegacyPHPResourceHandle
+  implements TCP\NonDisposableSocket, IO\NonDisposableReadWriteHandle {
+  use LegacyPHPResourceReadHandleTrait;
+  use LegacyPHPResourceWriteHandleTrait;
+
+  public function __construct(resource $impl) {
+    parent::__construct($impl);
+  }
+}

--- a/src/tcp/connect.php
+++ b/src/tcp/connect.php
@@ -1,0 +1,52 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\TCP;
+
+use namespace HH\Lib\_Private;
+use namespace HH\Lib\Experimental\Network;
+
+async function connect_nd_async(
+  string $host,
+  int $port,
+  Network\IPProtocolBehavior $ipver = Network\IPProtocolBehavior::PREFER_IPV6,
+): Awaitable<NonDisposableSocket> {
+  // TODO: implement a true async native `connect()` function
+
+  if ($ipver !== Network\IPProtocolBehavior::FORCE_IPV4) {
+    $sock = \socket_create(\AF_INET6, \SOCK_STREAM, \SOL_TCP);
+    if ($sock is resource && \socket_connect($sock, $host, $port)) {
+      return new _Private\NonDisposableTCPSocket($sock);
+    }
+  }
+  if ($ipver === Network\IPProtocolBehavior::FORCE_IPV6) {
+    throw new \Exception(
+      "Failed to connect: ".\socket_strerror(\socket_last_error()),
+    );
+  }
+  // We either have FORCE_IPV4, or PREFER_IPV6 but we failed to connect
+  $sock = \socket_create(\AF_INET, \SOCK_STREAM, \SOL_TCP);
+  if ($sock is resource && \socket_connect($sock, $host, $port)) {
+    return new _Private\NonDisposableTCPSocket($sock);
+  }
+  throw new \Exception(
+    "Failed to connect: ".\socket_strerror(\socket_last_error()),
+  );
+}
+
+<<__ReturnDisposable>>
+async function connect_async(
+  string $host,
+  int $port,
+  Network\IPProtocolBehavior $ipver = Network\IPProtocolBehavior::PREFER_IPV6,
+): Awaitable<DisposableSocket> {
+  $nd = await connect_nd_async($host, $port, $ipver);
+  return new _Private\DisposableTCPSocket($nd);
+}


### PR DESCRIPTION
No socket-specific features (such as peer address) are supported yet.

Test Plan:

No unit tests; will add when we also have async TCP server support.

```
use namespace HH\Lib\Experimental\TCP;

<<__EntryPoint>>
async function main(): Awaitable<void> {
  require_once('vendor/autoload.hack');
  \Facebook\AutoloadMap\initialize();

  await using $socket = await TCP\connect_async('example.com', 80);
  await $socket->writeAsync("GET / HTTP/1.0\r\nHost: www.example.com\r\n\r\n");
  for ($i = 0; $i < 20 && !$socket->isEndOfFile(); ++$i) {
    $line = await $socket->readLineAsync();
    print($line);
  }
}
```