### PR TITLE
[IO] Fix type bug in DisposableReadWriteHandle

### DIFF
--- a/src/io/DiposableReadWriteHandle.php
+++ b/src/io/DiposableReadWriteHandle.php
@@ -12,5 +12,6 @@ namespace HH\Lib\Experimental\IO;
 
 use namespace HH\Lib\Experimental\Fileystem;
 
-interface DisposableReadWriteHandle extends ReadWriteHandle, \IAsyncDisposable {
+interface DisposableReadWriteHandle
+  extends ReadWriteHandle, DisposableReadHandle, DisposableWriteHandle {
 }


### PR DESCRIPTION
Fix type issue with `DisposableReadWriteHandle` not being `DisposableReadHandle` or `DisposableWriteHandle` 


Reproduce the bug : 
 
```hack
async function a(
  <<__AcceptDisposable>> DisposableReadHandle $_handle
): Awaitable<void> {}

async function b(
  <<__AcceptDisposable>> DisposableWriteHandle $_handle
): Awaitable<void> {}

async function c(
  <<__AcceptDisposable>> DisposableReadWriteHandle $handle
): Awaitable<void> {
  await a($handle); // type error
  await b($handle); // type error
}
```