### PR TITLE
Use return value of `expect()->toThrow()` in tests

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -3,5 +3,5 @@ enable_experimental_tc_features = no_fallback_in_namespaces, re_prefixed_strings
 safe_array = true
 safe_vector_array = true
 unsafe_rx = false
-ignored_paths = [ "vendor/.+/tests/.+" ]
+ignored_paths = [ "vendor/.+/tests/.+", "vendor/bin/.+" ]
 user_attributes=

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   },
   "require-dev": {
     "hhvm/hacktest": "^1.0",
-    "facebook/fbexpect": "^2.0",
+    "facebook/fbexpect": "^2.7.0",
     "hhvm/hhvm-autoload": "^2.0"
   },
   "require": {

--- a/tests/file/FileTest.php
+++ b/tests/file/FileTest.php
@@ -26,15 +26,10 @@ final class FileTest extends HackTest {
     $f1 = File\open_write_only_nd($filename, File\WriteMode::MUST_CREATE);
     await $f1->writeAsync('Hello, world!');
     await $f1->flushAsync();
-    expect(async () ==> {
-      try {
-        await using (File\open_write_only($filename, File\WriteMode::MUST_CREATE)) {
-        };
-      } catch (File\OpenException $e) {
-        expect($e->getErrno())->toEqual(OS\Errno::EEXIST);
-        throw $e;
-      }
-    })->toThrow(File\OpenException::class);
+    $e = expect(
+      () ==> File\open_write_only_nd($filename, File\WriteMode::MUST_CREATE),
+    )->toThrow(File\OpenException::class);
+    expect($e->getErrno())->toEqual(OS\Errno::EEXIST);
     await $f1->closeAsync();
 
     await using $f2 = File\open_read_only($filename);

--- a/tests/tcp/HSLTCPTest.php
+++ b/tests/tcp/HSLTCPTest.php
@@ -123,17 +123,10 @@ final class HSLTCPTest extends HackTest {
   }
 
   public async function testConnectingToInvalidPort(): Awaitable<void> {
-    expect(
-      async () ==> {
-        try {
-          await using ($conn = await TCP\connect_async('localhost', 0)) {
-          }
-        } catch (Network\SocketException $e) {
-          expect(vec[OS\Errno::EADDRNOTAVAIL, OS\Errno::ECONNREFUSED])
-            ->toContain($e->getErrno());
-          throw $e;
-        }
-      },
-    )->toThrow(Network\SocketException::class);
+    $ex = expect(async () ==> await TCP\connect_nd_async('localhost', 0))
+      ->toThrow(Network\SocketException::class);
+    expect(vec[OS\Errno::EADDRNOTAVAIL, OS\Errno::ECONNREFUSED])->toContain(
+      $ex->getErrno(),
+    );
   }
 }


### PR DESCRIPTION
While I'm here:
- ignore vendor/bin/ as it's just symlinks, and leads to duplciate
  definition errors in incremental mode
- update minimum fbexpect version to include `toThrow()` with a return value