### PR TITLE
rework HSL IO exceptions

### DIFF
--- a/src/file/exceptions.php
+++ b/src/file/exceptions.php
@@ -12,23 +12,20 @@ namespace HH\Lib\Experimental\File;
 
 use namespace HH\Lib\Experimental\{IO, OS};
 
-abstract class Exception
+/**
+ * An exception thrown when opening a file fails.
+ */
+final class OpenException
   extends IO\Exception
-  implements OS\IExceptionWithErrno {
-
-  public function __construct(private OS\Errno $errno) {
-    parent::__construct();
-  }
-
-  public function getErrno(): OS\Errno {
-    return $this->errno;
-  }
+  implements IO\ExceptionWithErrno {
+  use OS\_Private\ExceptionWithErrnoTrait<OS\Errno>;
 }
-
-final class CreateException extends Exception {}
-final class OpenException extends Exception {}
 
 /**
  * An exception thrown when a file lock was not successfully acquired.
  */
-final class LockAcquisitionException extends Exception {}
+final class LockAcquisitionException
+  extends IO\Exception
+  implements IO\ExceptionWithErrno {
+  use OS\_Private\ExceptionWithErrnoTrait<OS\Errno>;
+}

--- a/src/io/Exception.php
+++ b/src/io/Exception.php
@@ -19,5 +19,5 @@ use namespace HH\Lib\Experimental\OS;
  */
 abstract class Exception
   extends \Exception
-  implements OS\IExceptionWithNullableErrno {
+  implements OS\ExceptionWithNullableErrno {
 }

--- a/src/io/ExceptionWithErrno.php
+++ b/src/io/ExceptionWithErrno.php
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 /*
  *  Copyright (c) 2004-present, Facebook, Inc.
  *  All rights reserved.
@@ -8,10 +8,11 @@
  *
  */
 
-namespace HH\Lib\Experimental\OS;
+namespace HH\Lib\Experimental\IO;
 
-interface IExceptionWithNullableErrno {
-  require extends \Exception;
+use namespace HH\Lib\Experimental\OS;
 
-  public function getErrno(): ?Errno;
+/** An IO exception with an `OS\Errno`. */
+interface ExceptionWithErrno extends OS\ExceptionWithErrno {
+  require extends Exception;
 }

--- a/src/io/InvalidHandleException.php
+++ b/src/io/InvalidHandleException.php
@@ -11,10 +11,18 @@
 
 namespace HH\Lib\Experimental\IO;
 
+use namespace HH\Lib\Experimental\OS;
+
 /** Indicates that an invalid handle was used or requested.
  *
- * For example, calling `IO\requestError()` throws this exception in an
+ * For example, calling `IO\request_error()` throws this exception in an
  * HTTP request, as the model only defines input and output streams, not an
  * error stream.
  */
-final class InvalidHandleException extends \Exception {}
+final class InvalidHandleException
+  extends Exception
+  implements ExceptionWithErrno {
+  public function getErrno(): OS\Errno {
+    return OS\Errno::EBADF;
+  }
+}

--- a/src/io/ReadException.php
+++ b/src/io/ReadException.php
@@ -12,12 +12,6 @@ namespace HH\Lib\Experimental\IO;
 
 use namespace HH\Lib\Experimental\OS;
 
-final class ReadException extends Exception implements OS\IExceptionWithErrno {
-  public function __construct(private OS\Errno $errno) {
-    parent::__construct();
-  }
-
-  public function getErrno(): OS\Errno {
-    return $this->errno;
-  }
+final class ReadException extends Exception implements ExceptionWithErrno {
+  use OS\_Private\ExceptionWithErrnoTrait<OS\Errno>;
 }

--- a/src/io/_Private/GenericException.php
+++ b/src/io/_Private/GenericException.php
@@ -8,10 +8,10 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\Experimental\IO\_Private;
 
-use namespace HH\Lib\Experimental\OS;
+use namespace HH\Lib\Experimental\{IO, OS};
 
-final class WriteException extends Exception implements ExceptionWithErrno {
+final class GenericException extends IO\Exception implements IO\ExceptionWithErrno {
   use OS\_Private\ExceptionWithErrnoTrait<OS\Errno>;
 }

--- a/src/io/_Private/SystemException.php
+++ b/src/io/_Private/SystemException.php
@@ -12,6 +12,13 @@ namespace HH\Lib\Experimental\IO\_Private;
 
 use namespace HH\Lib\Experimental\{IO, OS};
 
-final class GenericException extends IO\Exception implements IO\ExceptionWithErrno {
+/** Class for Errnos without a more-specific exception.
+ *
+ * DO NOT CATCH THIS DIRECTLY. Catch `IO\Exception` or `IO\ExceptionWithErrno`
+ * instead.
+ */
+final class SystemException
+  extends IO\Exception
+  implements IO\ExceptionWithErrno {
   use OS\_Private\ExceptionWithErrnoTrait<OS\Errno>;
 }

--- a/src/io/_Private/UnhandledOSErrnoException.php
+++ b/src/io/_Private/UnhandledOSErrnoException.php
@@ -17,7 +17,7 @@ use namespace HH\Lib\Experimental\{IO, OS};
  * DO NOT CATCH THIS DIRECTLY. Catch `IO\Exception` or `IO\ExceptionWithErrno`
  * instead.
  */
-final class SystemException
+final class UnhandledOSErrnoException
   extends IO\Exception
   implements IO\ExceptionWithErrno {
   use OS\_Private\ExceptionWithErrnoTrait<OS\Errno>;

--- a/src/network/_Private/throw_socket_error.php
+++ b/src/network/_Private/throw_socket_error.php
@@ -22,6 +22,6 @@ function throw_socket_error(string $_operation, int $errno): noreturn {
     case OS\Errno::EADDRNOTAVAIL:
       throw new Network\AddressNotAvailableException();
     default:
-      throw new IO\_Private\GenericException($errno as OS\Errno);
+      throw new IO\_Private\SystemException($errno as OS\Errno);
   }
 }

--- a/src/network/_Private/throw_socket_error.php
+++ b/src/network/_Private/throw_socket_error.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\Experimental\Network\_Private;
 
-use namespace HH\Lib\Experimental\{Network, OS};
+use namespace HH\Lib\Experimental\{IO, Network, OS};
 use namespace HH\Lib\Str;
 
 function throw_socket_error(string $_operation, int $errno): noreturn {
@@ -22,6 +22,6 @@ function throw_socket_error(string $_operation, int $errno): noreturn {
     case OS\Errno::EADDRNOTAVAIL:
       throw new Network\AddressNotAvailableException();
     default:
-      throw new Network\SocketException($errno as OS\Errno);
+      throw new IO\_Private\GenericException($errno as OS\Errno);
   }
 }

--- a/src/network/_Private/throw_socket_error.php
+++ b/src/network/_Private/throw_socket_error.php
@@ -22,6 +22,6 @@ function throw_socket_error(string $_operation, int $errno): noreturn {
     case OS\Errno::EADDRNOTAVAIL:
       throw new Network\AddressNotAvailableException();
     default:
-      throw new IO\_Private\SystemException($errno as OS\Errno);
+      throw new IO\_Private\UnhandledOSErrnoException($errno as OS\Errno);
   }
 }

--- a/src/network/exceptions.php
+++ b/src/network/exceptions.php
@@ -12,10 +12,6 @@ namespace HH\Lib\Experimental\Network;
 
 use namespace HH\Lib\Experimental\{IO, OS};
 
-abstract class Exception extends IO\Exception {
-  abstract public function getHErrno(): ?OS\HErrno;
-}
-
 /**
  * Exception thrown if a host name could not be resolved to an
  * address usable for the socket type.
@@ -23,12 +19,12 @@ abstract class Exception extends IO\Exception {
  * You may also want to catch `SocketException`, or the base
  * `Network\Exception`.
  */
-final class HostResolutionException extends Exception {
+final class HostResolutionException extends IO\Exception {
   public function __construct(private OS\HErrno $herrno) {
     parent::__construct();
   }
 
-  public function getErrno(): null  {
+  public function getErrno(): null {
     return null;
   }
 
@@ -37,28 +33,10 @@ final class HostResolutionException extends Exception {
   }
 }
 
-/**
- * Class for exceptions in socket calls.
- *
- * Sites that catch this likely want to also catch `HostResolutionException`, or
- * just `Network\Exception`.
- */
-class SocketException extends Exception implements OS\IExceptionWithErrno {
-  public function __construct(private OS\Errno $errno) {
-    parent::__construct();
-  }
-
+final class AddressNotAvailableException
+  extends IO\Exception
+  implements IO\ExceptionWithErrno {
   public function getErrno(): OS\Errno {
-    return $this->errno;
-  }
-
-  public function getHErrno(): null {
-    return null;
-  }
-}
-
-final class AddressNotAvailableException extends SocketException {
-  public function __construct() {
-    parent::__construct(OS\Errno::EADDRNOTAVAIL);
+    return OS\Errno::EADDRNOTAVAIL;
   }
 }

--- a/src/os/ExceptionWithErrno.php
+++ b/src/os/ExceptionWithErrno.php
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 /*
  *  Copyright (c) 2004-present, Facebook, Inc.
  *  All rights reserved.
@@ -8,10 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\Experimental\OS;
 
-use namespace HH\Lib\Experimental\OS;
+interface ExceptionWithErrno extends ExceptionWithNullableErrno {
 
-final class WriteException extends Exception implements ExceptionWithErrno {
-  use OS\_Private\ExceptionWithErrnoTrait<OS\Errno>;
+  public function getErrno(): Errno;
 }

--- a/src/os/ExceptionWithNullableErrno.php
+++ b/src/os/ExceptionWithNullableErrno.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\Experimental\OS;
 
-interface IExceptionWithErrno extends IExceptionWithNullableErrno {
+interface ExceptionWithNullableErrno {
+  require extends \Exception;
 
-  public function getErrno(): Errno;
+  public function getErrno(): ?Errno;
 }

--- a/src/os/_Private.php
+++ b/src/os/_Private.php
@@ -20,3 +20,18 @@ function errno(): ?OS\Errno {
   $errno = \posix_get_last_error() as int;
   return $errno === 0 ? null : OS\Errno::assert($errno);
 }
+
+trait ExceptionWithErrnoTrait<T as ?OS\Errno> {
+  require extends \Exception;
+
+  private T $errno;
+
+  final public function __construct(T $errno) {
+    $this->errno = $errno;
+    parent::__construct();
+  }
+
+  public function getErrno(): T {
+    return $this->errno;
+  }
+}

--- a/tests/tcp/HSLTCPTest.php
+++ b/tests/tcp/HSLTCPTest.php
@@ -9,7 +9,7 @@
  */
 
 use namespace HH\Lib\Vec;
-use namespace HH\Lib\Experimental\{Network, OS, TCP};
+use namespace HH\Lib\Experimental\{IO, Network, OS, TCP};
 
 use function Facebook\FBExpect\expect; // @oss-enable
 use type HH\InvariantException as InvalidRegexException; // @oss-enable
@@ -124,7 +124,7 @@ final class HSLTCPTest extends HackTest {
 
   public async function testConnectingToInvalidPort(): Awaitable<void> {
     $ex = expect(async () ==> await TCP\connect_nd_async('localhost', 0))
-      ->toThrow(Network\SocketException::class);
+      ->toThrow(IO\ExceptionWithErrno::class);
     expect(vec[OS\Errno::EADDRNOTAVAIL, OS\Errno::ECONNREFUSED])->toContain(
       $ex->getErrno(),
     );


### PR DESCRIPTION
- remove `File\Exception`, `Network\Exception`, and `Socket\Exception` as
  there does not seem to be anything useful you can do with them: they
  should either be treated the same as an `IO\Exception`, or you need a
  more specific subclass
- add `IO\ExceptionWithErrno`; with intersection types, this would
  probably not exist (`catch ((IO\Exception & OS\ExceptionWithErrno)
  $e)`)
- remove `I` prefixes from interfaces as we're not currently using that
  in the main HSL
- extract basic 'errno in constructor' behavior to a trait