### PR TITLE
remove lies_we_tell_hack.hhi from HSL (#98)

### DIFF
--- a/tests/file/FileTest.php
+++ b/tests/file/FileTest.php
@@ -13,7 +13,6 @@ use namespace HH\Lib\{Str, Tuple};
 use namespace HH\Lib\Experimental\OS;
 
 use function Facebook\FBExpect\expect; // @oss-enable
-use type HH\InvariantException as InvalidRegexException; // @oss-enable
 use type Facebook\HackTest\HackTest; // @oss-enable
 // @oss-disable: use type HackTest;
 

--- a/tests/file/PathTest.php
+++ b/tests/file/PathTest.php
@@ -13,7 +13,6 @@ use namespace HH\Lib\Experimental\File;
 
 use function Facebook\FBExpect\expect; // @oss-enable
 use type Facebook\HackTest\HackTest; // @oss-enable
-use type HH\InvariantException as InvalidRegexException; // @oss-enable
 use type Facebook\HackTest\DataProvider; // @oss-enable
 // @oss-disable: use type HackTest;
 

--- a/tests/tcp/HSLTCPTest.php
+++ b/tests/tcp/HSLTCPTest.php
@@ -12,7 +12,6 @@ use namespace HH\Lib\Vec;
 use namespace HH\Lib\Experimental\{Network, OS, TCP};
 
 use function Facebook\FBExpect\expect; // @oss-enable
-use type HH\InvariantException as InvalidRegexException; // @oss-enable
 use type Facebook\HackTest\HackTest; // @oss-enable
 use type Facebook\HackTest\DataProvider; // @oss-enable
 // @oss-disable: use type HackTest;

--- a/tests/unix/HSLUnixSocketTest.php
+++ b/tests/unix/HSLUnixSocketTest.php
@@ -12,7 +12,6 @@ use namespace HH\Lib\Experimental\{Network, Unix};
 use namespace HH\Lib\{Math, PseudoRandom};
 
 use function Facebook\FBExpect\expect; // @oss-enable
-use type HH\InvariantException as InvalidRegexException; // @oss-enable
 use type Facebook\HackTest\HackTest; // @oss-enable
 use type Facebook\HackTest\DataProvider; // @oss-enable
 // @oss-disable: use type HackTest;


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/hhvm/hsl/pull/98

In HSL and open-source projects that depend on it, most of these "lies" are unneeded, and the remaining places that depend on them can be avoided by changing `\HH\InvariantException` to `InvariantException`. Without namespace, it will always be correctly resolved to wherever HHVM autoimports it from.

"wherever HHVM autoimports it from" is actually changing (it used to be `\InvariantException` but is `\HH\InvariantException` as of a few days ago), which is the reason why this file is problematic. Before the HHVM change, and without the diff, the file was needed -- but after the HHVM change, the file causes Hack errors in HSL and [anything that depends on it](https://travis-ci.org/hhvm/)).

Reviewed By: fredemmott

Differential Revision: D18121499

