### PR TITLE
Split blocking- and non-blocking locks to separate functions

### DIFF
--- a/src/file/AlreadyLockedException.php
+++ b/src/file/AlreadyLockedException.php
@@ -1,0 +1,21 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\File;
+
+/**
+ * Indicates that a lock failed, because the file is already locked.
+ *
+ * This class does not extend `OS\Exception` as an `EWOULDBLOCK` after
+ * `flock($fd, LOCK_NB)` is expected rather than an error; this exception is
+ * thrown when the caller has explicitly requested an exception for these cases.
+ */
+final class AlreadyLockedException extends \Exception {
+}

--- a/src/file/Handle.php
+++ b/src/file/Handle.php
@@ -29,8 +29,26 @@ interface Handle extends IO\SeekableHandle {
    */
   public function getSize(): int;
 
+  /**
+   * Get a shared or exclusive lock on the file.
+   *
+   * This will block until it acquires the lock, which may be forever.
+   *
+   * This involves a blocking syscall; async code will not execute while
+   * waiting for a lock.
+   */
   <<__ReturnDisposable>>
   public function lock(LockType $mode): Lock;
+
+  /**
+   * Immediately get a shared or exclusive lock on a file, or throw.
+   *
+   * @throws `File\AlreadyLockedException` if `lock()` would block. **This
+   *   is not a subclass of `OS\Exception`**.
+   * @throws `OS\Exception` in any other case.
+   */
+  <<__ReturnDisposable>>
+  public function tryLockx(LockType $mode): Lock;
 }
 
 <<__Sealed(

--- a/src/file/Lock.php
+++ b/src/file/Lock.php
@@ -21,29 +21,14 @@ use namespace HH\Lib\Experimental\{IO, OS};
  * is not desired behavior it should be guarded against.
  */
 final class Lock implements \IDisposable {
-  private resource $resource;
 
-  public function __construct(
-    <<__AcceptDisposable>> Handle $handle,
-    LockType $lock_type,
-  ) {
-    $this->resource =
-      /* HH_IGNORE_ERROR[4179] doing dodgy things to disposables */
-      /* HH_IGNORE_ERROR[4188] doing dodgy things to disposables */
-      ($handle as _Private\NonDisposableFileHandle)->__getResource_DO_NOT_USE();
-    $_wouldblock = null;
-    /* HH_IGNORE_ERROR[2049] __PHPStdLib */
-    /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-    $flock_result = \flock($this->resource, $lock_type, inout $_wouldblock);
-    if (!$flock_result) {
-      OS\_Private\throw_errno(OS\_Private\errnox('flock'), "flock failed");
-    }
+  public function __construct(private resource $handle) {
   }
 
   final public function __dispose(): void {
     $_wouldblock = null;
     /* HH_IGNORE_ERROR[2049] __PHPStdLib */
     /* HH_IGNORE_ERROR[4107] __PHPStdLib */
-    \flock($this->resource, \LOCK_UN, inout $_wouldblock);
+    \flock($this->handle, \LOCK_UN, inout $_wouldblock);
   }
 }

--- a/src/file/LockType.php
+++ b/src/file/LockType.php
@@ -19,22 +19,8 @@ enum LockType: int as int {
   SHARED = \LOCK_SH;
 
   /**
-   * Like a shared lock, but the creation of a Lock will throw a
-   * `LockAcquisitionException` if the lock was not acquired instead of
-   * blocking.
-   */
-  SHARED_NON_BLOCKING = \LOCK_SH | \LOCK_NB;
-
-  /**
    * Only a single process may possess an exclusive lock to a given file at a
    * time. The creation of a Lock will block until the lock is acquired.
    */
   EXCLUSIVE = \LOCK_EX;
-
-  /**
-   * Like an exclusive lock, but the creation of a Lock will throw a
-   * `LockAcquisitionException` if the lock was not acquired instead of
-   * blocking.
-   */
-  EXCLUSIVE_NON_BLOCKING = \LOCK_EX | \LOCK_NB;
 }

--- a/src/file/_Private/DisposableFileHandle.php
+++ b/src/file/_Private/DisposableFileHandle.php
@@ -33,6 +33,11 @@ abstract class DisposableFileHandle<T as NonDisposableFileHandle>
     return $this->impl->lock($type);
   }
 
+  <<__ReturnDisposable>>
+  final public function tryLockx(File\LockType $type): File\Lock {
+    return $this->impl->tryLockx($type);
+  }
+
   final public async function seekAsync(int $offset): Awaitable<void> {
     await $this->impl->seekAsync($offset);
   }


### PR DESCRIPTION
`tryLockx()` will throw an AlreadyLockedException; `lock()` will block and wait for it

Depends on (and includes) #79