### PR TITLE
Add a bunch of exceptions

### DIFF
--- a/src/file/_Private/NonDisposableFileHandle.php
+++ b/src/file/_Private/NonDisposableFileHandle.php
@@ -10,6 +10,7 @@
 
 namespace HH\Lib\Experimental\File\_Private;
 
+use namespace HH\Lib\Str;
 use namespace HH\Lib\Experimental\{IO, File, OS};
 use type HH\Lib\_Private\PHPWarningSuppressor;
 
@@ -26,8 +27,11 @@ abstract class NonDisposableFileHandle
     /* HH_IGNORE_ERROR[2049] __PHPStdLib */
     /* HH_IGNORE_ERROR[4107] __PHPStdLib */
     $f = \fopen($path, $mode);
+    /* HH_IGNORE_ERROR[2049] PHPStdLib */
+    /* HH_IGNORE_ERROR[4107] PHPStdLib */
+    $errno = \posix_get_last_error() as int;
     if ($f === false) {
-      OS\_Private\throw_errno(OS\_Private\errnox('fopen'), 'fopen failed');
+      OS\_Private\throw_errno($errno, 'fopen');
     }
     $this->filename = $path;
     parent::__construct($f);
@@ -58,10 +62,13 @@ abstract class NonDisposableFileHandle
     /* HH_IGNORE_ERROR[2049] __PHPStdLib */
     /* HH_IGNORE_ERROR[4107] __PHPStdLib */
     $success = \flock($impl, $type, inout $would_block);
+    /* HH_IGNORE_ERROR[2049] __PHPStdLib */
+    /* HH_IGNORE_ERROR[4107] __PHPStdLib */
+    $errno = \posix_get_last_error();
     if ($success) {
       return new File\Lock($impl);
     }
-    OS\_Private\throw_errno(OS\_Private\errnox('flock'), 'flock() failed');
+    OS\_Private\throw_errno($errno as int, 'flock');
   }
 
   <<__ReturnDisposable>>
@@ -71,13 +78,16 @@ abstract class NonDisposableFileHandle
     /* HH_IGNORE_ERROR[2049] __PHPStdLib */
     /* HH_IGNORE_ERROR[4107] __PHPStdLib */
     $success = \flock($impl, $type | \LOCK_NB, inout $would_block);
+    /* HH_IGNORE_ERROR[2049] __PHPStdLib */
+    /* HH_IGNORE_ERROR[4107] __PHPStdLib */
+    $errno = \posix_get_last_error();
     if ($success) {
       return new File\Lock($impl);
     }
     if ($would_block) {
       throw new File\AlreadyLockedException();
     }
-    OS\_Private\throw_errno(OS\_Private\errnox('flock'), 'flock() failed');
+    OS\_Private\throw_errno($errno as int, 'flock');
   }
 
 

--- a/src/io/_Private/LegacyPHPResourceReadHandleTrait.php
+++ b/src/io/_Private/LegacyPHPResourceReadHandleTrait.php
@@ -28,11 +28,11 @@ trait LegacyPHPResourceReadHandleTrait implements IO\ReadHandle {
     /* HH_IGNORE_ERROR[2049] __PHPStdLib */
     /* HH_IGNORE_ERROR[4107] __PHPStdLib */
     $result = \stream_get_contents($this->impl, $max_bytes ?? -1);
+    /* HH_IGNORE_ERROR[2049] __PHPStdLib */
+    /* HH_IGNORE_ERROR[4107] __PHPStdLib */
+    $errno = \posix_get_last_error();
     if ($result === false) {
-      OS\_Private\throw_errno(
-        OS\_Private\errnox('stream_get_contents'),
-        'stream_get_contents() failed',
-      );
+      OS\_Private\throw_errno($errno as int, 'stream_get_contents');
     }
     return $result as string;
   }

--- a/src/io/_Private/LegacyPHPResourceWriteHandleTrait.php
+++ b/src/io/_Private/LegacyPHPResourceWriteHandleTrait.php
@@ -22,8 +22,11 @@ trait LegacyPHPResourceWriteHandleTrait implements IO\WriteHandle {
     /* HH_IGNORE_ERROR[2049] __PHPStdLib */
     /* HH_IGNORE_ERROR[4107] __PHPStdLib */
     $result = \fwrite($this->impl, $bytes);
+    /* HH_IGNORE_ERROR[2049] __PHPStdLib */
+    /* HH_IGNORE_ERROR[4107] __PHPStdLib */
+    $errno = \posix_get_last_error();
     if ($result === false) {
-      OS\_Private\throw_errno(OS\_Private\errnox('fwrite'), "fwrite() failed");
+      OS\_Private\throw_errno($errno, 'fwrite');
     }
     return $result as int;
   }

--- a/src/os/ErrorCode.php
+++ b/src/os/ErrorCode.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\Experimental\OS;
 
-enum ErrorCode : string {
+enum ErrorCode: string as string {
   ///// errno values /////
   EPERM = "EPERM";
   ENOENT = "ENOENT";
@@ -43,7 +43,7 @@ enum ErrorCode : string {
   ESPIPE = "ESPIPE";
   EROFS = "EROFS";
   EMLINK = "EMLINK";
-  EMPIPE = "EMPIPE";
+  EPIPE = "EPIPE";
   EDOM = "EDOM";
   ERANGE = "ERANGE";
   EDEADLK = "EDEADLK";

--- a/src/os/Exception.php
+++ b/src/os/Exception.php
@@ -10,12 +10,8 @@
 
 namespace HH\Lib\Experimental\OS;
 
-// todo: extend for common cases; consider sealing vs leaving fully open.
-final class Exception extends \Exception {
-  public function __construct(
-    private ErrorCode $errorCode,
-    string $message,
-  ) {
+class Exception extends \Exception {
+  public function __construct(private ErrorCode $errorCode, string $message) {
     parent::__construct($message);
   }
 

--- a/src/os/_Private.php
+++ b/src/os/_Private.php
@@ -13,20 +13,3 @@ namespace HH\Lib\Experimental\OS\_Private;
 use namespace HH\Lib\Experimental\OS;
 
 const bool IS_MACOS = \PHP_OS === 'Darwin';
-
-function errno(): ?Errno {
-  /* HH_IGNORE_ERROR[2049] PHPStdLib */
-  /* HH_IGNORE_ERROR[4107] PHPStdLib */
-  $errno = \posix_get_last_error() as int;
-  return $errno === 0 ? null : Errno::assert($errno);
-}
-
-function errnox(string $caller): Errno {
-  $errno = errno();
-  invariant(
-    $errno is nonnull,
-    '%s() indicated failure, but errno indicated success',
-    $caller,
-  );
-  return $errno;
-}

--- a/src/os/_Private/exceptions.php
+++ b/src/os/_Private/exceptions.php
@@ -1,0 +1,40 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\OS\_Private;
+
+use namespace HH\Lib\C;
+use namespace HH\Lib\Experimental\OS;
+
+trait ExceptionWithMultipleErrorCodesTrait {
+  require extends OS\Exception;
+
+  final public function __construct(OS\ErrorCode $code, string $message) {
+    invariant(
+      C\contains(static::_getValidErrorCodes(), $code),
+      'Exception %s constructed with invalid code %s',
+      static::class,
+      $code,
+    );
+    parent::__construct($code, $message);
+  }
+
+  abstract public static function _getValidErrorCodes(): keyset<OS\ErrorCode>;
+}
+
+trait ExceptionWithSingleErrorCodeTrait {
+  require extends OS\Exception;
+
+  final public function __construct(string $message) {
+    parent::__construct(static::_getValidErrorCode(), $message);
+  }
+
+  abstract public static function _getValidErrorCode(): OS\ErrorCode;
+}

--- a/src/os/exceptions.php
+++ b/src/os/exceptions.php
@@ -1,0 +1,115 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Experimental\OS;
+
+use namespace HH\Lib\C;
+
+final class ChildProcessException extends Exception {
+  use _Private\ExceptionWithSingleErrorCodeTrait;
+
+  public static function _getValidErrorCode(): ErrorCode {
+    return ErrorCode::ECHILD;
+  }
+}
+
+abstract class ConnectionException extends Exception {
+}
+
+final class BrokenPipeException extends ConnectionException {
+  use _Private\ExceptionWithMultipleErrorCodesTrait;
+
+  public static function _getValidErrorCodes(): keyset<ErrorCode> {
+    return keyset[ErrorCode::EPIPE, ErrorCode::ESHUTDOWN];
+  }
+}
+
+final class ConnectionAbortedException extends ConnectionException {
+  use _Private\ExceptionWithSingleErrorCodeTrait;
+
+  public static function _getValidErrorCode(): ErrorCode {
+    return ErrorCode::ECONNABORTED;
+  }
+}
+
+final class ConnectionRefusedException extends ConnectionException {
+  use _Private\ExceptionWithSingleErrorCodeTrait;
+
+  public static function _getValidErrorCode(): ErrorCode {
+    return ErrorCode::ECONNREFUSED;
+  }
+}
+
+final class ConnectionResetException extends ConnectionException {
+  use _Private\ExceptionWithSingleErrorCodeTrait;
+
+  public static function _getValidErrorCode(): ErrorCode {
+    return ErrorCode::ECONNRESET;
+  }
+}
+
+final class AlreadyExistsException extends Exception {
+  use _Private\ExceptionWithSingleErrorCodeTrait;
+
+  public static function _getValidErrorCode(): ErrorCode {
+    return ErrorCode::EEXIST;
+  }
+}
+
+final class NotFoundException extends Exception {
+  use _Private\ExceptionWithSingleErrorCodeTrait;
+
+  public static function _getValidErrorCode(): ErrorCode {
+    return ErrorCode::ENOENT;
+  }
+}
+
+final class IsADirectoryException extends Exception {
+  use _Private\ExceptionWithSingleErrorCodeTrait;
+
+  public static function _getValidErrorCode(): ErrorCode {
+    return ErrorCode::EISDIR;
+  }
+}
+
+final class IsNotADirectoryException extends Exception {
+  use _Private\ExceptionWithSingleErrorCodeTrait;
+
+  public static function _getValidErrorCode(): ErrorCode {
+    return ErrorCode::ENOTDIR;
+  }
+}
+
+final class PermissionException extends Exception {
+  use _Private\ExceptionWithMultipleErrorCodesTrait;
+
+  public static function _getValidErrorCodes(): keyset<ErrorCode> {
+    return keyset[
+      ErrorCode::EACCES,
+      ErrorCode::EPERM,
+    ];
+  }
+}
+
+final class ProcessLookupException extends Exception {
+  use _Private\ExceptionWithSingleErrorCodeTrait;
+
+  public static function _getValidErrorCode(): ErrorCode {
+    return ErrorCode::ESRCH;
+  }
+}
+
+final class TimeoutError extends Exception {
+  use _Private\ExceptionWithSingleErrorCodeTrait;
+
+  public static function _getValidErrorCode(): ErrorCode {
+    return ErrorCode::ETIMEDOUT;
+  }
+}


### PR DESCRIPTION
Add a bunch of exceptions

fixes #37

This is basically Python3's list, except:
- FileExistsError -> AlreadyExistsException (not file-specific)
- FileNotFoundError -> NotFoundException (not file-specific)
- No InterruptError (EINTR) as that should be an auto-retry
- No BlockingIOError (EGAIN, EALREADY, EWOULDBLOCK, EINPROGRESS) as
  auto-retry or complicated (e.g. loccking)

Using Python's list as it's a well-thought-out starting place with some
practical experience.

Removed the errno/errnox wrappers; they're unreliable due to fetching
`errno` being inheriently racy.