### PR TITLE
[hsl io] Rename *NonDisposable* to *Closeable*

### DIFF
--- a/src/file/CloseableReadHandle.php
+++ b/src/file/CloseableReadHandle.php
@@ -12,9 +12,8 @@ namespace HH\Lib\Experimental\File;
 
 use namespace HH\Lib\Experimental\IO;
 
-final class NonDisposableReadWriteHandle
-  extends _Private\NonDisposableFileHandle
-  implements ReadWriteHandle, IO\NonDisposableSeekableReadWriteHandle {
+final class CloseableReadHandle
+  extends _Private\CloseableFileHandle
+  implements ReadHandle, IO\CloseableSeekableReadHandle {
   use IO\_Private\LegacyPHPResourceReadHandleTrait;
-  use IO\_Private\LegacyPHPResourceWriteHandleTrait;
 }

--- a/src/file/CloseableReadWriteHandle.php
+++ b/src/file/CloseableReadWriteHandle.php
@@ -12,8 +12,9 @@ namespace HH\Lib\Experimental\File;
 
 use namespace HH\Lib\Experimental\IO;
 
-final class NonDisposableWriteHandle
-  extends _Private\NonDisposableFileHandle
-  implements WriteHandle, IO\NonDisposableSeekableWriteHandle {
+final class CloseableReadWriteHandle
+  extends _Private\CloseableFileHandle
+  implements ReadWriteHandle, IO\CloseableSeekableReadWriteHandle {
+  use IO\_Private\LegacyPHPResourceReadHandleTrait;
   use IO\_Private\LegacyPHPResourceWriteHandleTrait;
 }

--- a/src/file/CloseableWriteHandle.php
+++ b/src/file/CloseableWriteHandle.php
@@ -12,8 +12,8 @@ namespace HH\Lib\Experimental\File;
 
 use namespace HH\Lib\Experimental\IO;
 
-final class NonDisposableReadHandle
-  extends _Private\NonDisposableFileHandle
-  implements ReadHandle, IO\NonDisposableSeekableReadHandle {
-  use IO\_Private\LegacyPHPResourceReadHandleTrait;
+final class CloseableWriteHandle
+  extends _Private\CloseableFileHandle
+  implements WriteHandle, IO\CloseableSeekableWriteHandle {
+  use IO\_Private\LegacyPHPResourceWriteHandleTrait;
 }

--- a/src/file/Handle.php
+++ b/src/file/Handle.php
@@ -14,7 +14,7 @@ use namespace HH\Lib\Experimental\IO;
 
 <<__Sealed(
   _Private\DisposableFileHandle::class,
-  _Private\NonDisposableFileHandle::class,
+  _Private\CloseableFileHandle::class,
   ReadHandle::class,
   WriteHandle::class,
 )>>
@@ -54,7 +54,7 @@ interface Handle extends IO\SeekableHandle {
 <<__Sealed(
   DisposableReadHandle::class,
   ReadWriteHandle::class,
-  NonDisposableReadHandle::class,
+  CloseableReadHandle::class,
 )>>
 interface ReadHandle extends Handle, IO\SeekableReadHandle {
 }
@@ -62,13 +62,13 @@ interface ReadHandle extends Handle, IO\SeekableReadHandle {
 <<__Sealed(
   DisposableWriteHandle::class,
   ReadWriteHandle::class,
-  NonDisposableWriteHandle::class,
+  CloseableWriteHandle::class,
 )>>
 interface WriteHandle extends Handle, IO\SeekableWriteHandle {
 }
 
 <<__Sealed(
-  NonDisposableReadWriteHandle::class,
+  CloseableReadWriteHandle::class,
   DisposableReadWriteHandle::class,
 )>>
 interface ReadWriteHandle extends WriteHandle, ReadHandle, IO\SeekableReadWriteHandle {

--- a/src/file/_Private/CloseableFileHandle.php
+++ b/src/file/_Private/CloseableFileHandle.php
@@ -15,9 +15,9 @@ use namespace HH\Lib\Experimental\{IO, File, OS};
 use type HH\Lib\_Private\PHPWarningSuppressor;
 
 <<__ConsistentConstruct>>
-abstract class NonDisposableFileHandle
+abstract class CloseableFileHandle
   extends IO\_Private\LegacyPHPResourceHandle
-  implements File\Handle, IO\NonDisposableHandle {
+  implements File\Handle, IO\CloseableHandle {
   use IO\_Private\LegacyPHPResourceSeekableHandleTrait;
 
   protected string $filename;

--- a/src/file/_Private/DisposableFileHandle.php
+++ b/src/file/_Private/DisposableFileHandle.php
@@ -13,7 +13,7 @@ namespace HH\Lib\Experimental\File\_Private;
 use namespace HH\Lib\Experimental\{File, IO};
 
 <<__ConsistentConstruct>>
-abstract class DisposableFileHandle<T as NonDisposableFileHandle>
+abstract class DisposableFileHandle<T as CloseableFileHandle>
   extends IO\_Private\DisposableHandleWrapper<T>
   implements File\Handle {
   final public function __construct(T $impl) {

--- a/src/file/_Private/DisposableFileReadHandle.php
+++ b/src/file/_Private/DisposableFileReadHandle.php
@@ -13,7 +13,7 @@ namespace HH\Lib\Experimental\File\_Private;
 use namespace HH\Lib\Experimental\{File, IO};
 
 final class DisposableFileReadHandle
-  extends DisposableFileHandle<File\NonDisposableReadHandle>
+  extends DisposableFileHandle<File\CloseableReadHandle>
   implements File\DisposableReadHandle {
-  use IO\_Private\DisposableReadHandleWrapperTrait<File\NonDisposableReadHandle>;
+  use IO\_Private\DisposableReadHandleWrapperTrait<File\CloseableReadHandle>;
 }

--- a/src/file/_Private/DisposableFileReadWriteHandle.php
+++ b/src/file/_Private/DisposableFileReadWriteHandle.php
@@ -13,8 +13,8 @@ namespace HH\Lib\Experimental\File\_Private;
 use namespace HH\Lib\Experimental\{File, IO};
 
 final class DisposableFileReadWriteHandle
-  extends DisposableFileHandle<File\NonDisposableReadWriteHandle>
+  extends DisposableFileHandle<File\CloseableReadWriteHandle>
   implements File\DisposableReadWriteHandle {
-  use IO\_Private\DisposableReadHandleWrapperTrait<File\NonDisposableReadWriteHandle>;
-  use IO\_Private\DisposableWriteHandleWrapperTrait<File\NonDisposableReadWriteHandle>;
+  use IO\_Private\DisposableReadHandleWrapperTrait<File\CloseableReadWriteHandle>;
+  use IO\_Private\DisposableWriteHandleWrapperTrait<File\CloseableReadWriteHandle>;
 }

--- a/src/file/_Private/DisposableFileWriteHandle.php
+++ b/src/file/_Private/DisposableFileWriteHandle.php
@@ -13,7 +13,7 @@ namespace HH\Lib\Experimental\File\_Private;
 use namespace HH\Lib\Experimental\{File, IO};
 
 final class DisposableFileWriteHandle
-  extends DisposableFileHandle<File\NonDisposableWriteHandle>
+  extends DisposableFileHandle<File\CloseableWriteHandle>
   implements File\DisposableWriteHandle {
-  use IO\_Private\DisposableWriteHandleWrapperTrait<File\NonDisposableWriteHandle>;
+  use IO\_Private\DisposableWriteHandleWrapperTrait<File\CloseableWriteHandle>;
 }

--- a/src/file/_Private/TemporaryFile.php
+++ b/src/file/_Private/TemporaryFile.php
@@ -13,10 +13,10 @@ namespace HH\Lib\Experimental\File\_Private;
 use namespace HH\Lib\Experimental\{File, IO};
 
 final class TemporaryFile
-  extends DisposableFileHandle<File\NonDisposableReadWriteHandle>
+  extends DisposableFileHandle<File\CloseableReadWriteHandle>
   implements File\DisposableReadWriteHandle {
-  use IO\_Private\DisposableReadHandleWrapperTrait<File\NonDisposableReadWriteHandle>;
-  use IO\_Private\DisposableWriteHandleWrapperTrait<File\NonDisposableReadWriteHandle>;
+  use IO\_Private\DisposableReadHandleWrapperTrait<File\CloseableReadWriteHandle>;
+  use IO\_Private\DisposableWriteHandleWrapperTrait<File\CloseableReadWriteHandle>;
 
   public async function __disposeAsync(): Awaitable<void> {
     await parent::__disposeAsync();

--- a/src/file/open.php
+++ b/src/file/open.php
@@ -10,9 +10,9 @@
 
 namespace HH\Lib\Experimental\File;
 
-function open_read_only_nd(string $path): NonDisposableReadHandle {
+function open_read_only_nd(string $path): CloseableReadHandle {
   return
-    NonDisposableReadHandle::__createInstance_IMPLEMENTATION_DETAIL_DO_NOT_USE(
+    CloseableReadHandle::__createInstance_IMPLEMENTATION_DETAIL_DO_NOT_USE(
       $path,
       'rb',
     );
@@ -21,9 +21,9 @@ function open_read_only_nd(string $path): NonDisposableReadHandle {
 function open_write_only_nd(
   string $path,
   WriteMode $mode = WriteMode::OPEN_OR_CREATE,
-): NonDisposableWriteHandle {
+): CloseableWriteHandle {
   return
-    NonDisposableWriteHandle::__createInstance_IMPLEMENTATION_DETAIL_DO_NOT_USE(
+    CloseableWriteHandle::__createInstance_IMPLEMENTATION_DETAIL_DO_NOT_USE(
       $path,
       $mode as string,
     );
@@ -32,9 +32,9 @@ function open_write_only_nd(
 function open_read_write_nd(
   string $path,
   WriteMode $mode = WriteMode::OPEN_OR_CREATE,
-): NonDisposableReadWriteHandle {
+): CloseableReadWriteHandle {
   return
-    NonDisposableReadWriteHandle::__createInstance_IMPLEMENTATION_DETAIL_DO_NOT_USE(
+    CloseableReadWriteHandle::__createInstance_IMPLEMENTATION_DETAIL_DO_NOT_USE(
       $path,
       ($mode as string).'+',
     );

--- a/src/io/CloseableHandle.php
+++ b/src/io/CloseableHandle.php
@@ -10,8 +10,6 @@
 
 namespace HH\Lib\Experimental\IO;
 
-interface NonDisposableSeekableReadHandle extends
-  SeekableReadHandle,
-  NonDisposableReadHandle,
-  NonDisposableSeekableHandle {
+interface CloseableHandle extends Handle {
+  public function closeAsync(): Awaitable<void>;
 }

--- a/src/io/CloseableReadHandle.php
+++ b/src/io/CloseableReadHandle.php
@@ -8,11 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\TCP;
+namespace HH\Lib\Experimental\IO;
 
-use namespace HH\Lib\Experimental\Network;
-
-<<__Sealed(_Private\NonDisposableTCPSocket::class)>>
-interface NonDisposableSocket
-  extends Socket, Network\NonDisposableSocket {
+interface CloseableReadHandle extends ReadHandle, CloseableHandle {
 }

--- a/src/io/CloseableReadWriteHandle.php
+++ b/src/io/CloseableReadWriteHandle.php
@@ -8,10 +8,8 @@
  *
  */
 
-namespace HH\Lib\Experimental\Unix;
+namespace HH\Lib\Experimental\IO;
 
-use namespace HH\Lib\Experimental\Network;
-
-<<__Sealed(_Private\NonDisposableSocket::class)>>
-interface NonDisposableSocket extends Socket, Network\NonDisposableSocket {
+interface CloseableReadWriteHandle
+  extends ReadWriteHandle, CloseableReadHandle, CloseableWriteHandle {
 }

--- a/src/io/CloseableSeekableHandle.php
+++ b/src/io/CloseableSeekableHandle.php
@@ -10,11 +10,6 @@
 
 namespace HH\Lib\Experimental\IO;
 
-interface NonDisposableSeekableReadWriteHandle
-  extends
-    SeekableReadWriteHandle,
-    NonDisposableReadWriteHandle,
-    NonDisposableSeekableHandle,
-    NonDisposableSeekableReadHandle,
-    NonDisposableSeekableWriteHandle {
+interface CloseableSeekableHandle
+  extends SeekableHandle, CloseableHandle {
 }

--- a/src/io/CloseableSeekableReadHandle.php
+++ b/src/io/CloseableSeekableReadHandle.php
@@ -10,8 +10,8 @@
 
 namespace HH\Lib\Experimental\IO;
 
-interface NonDisposableSeekableWriteHandle extends
-  SeekableWriteHandle,
-  NonDisposableSeekableHandle,
-  NonDisposableWriteHandle {
+interface CloseableSeekableReadHandle extends
+  SeekableReadHandle,
+  CloseableReadHandle,
+  CloseableSeekableHandle {
 }

--- a/src/io/CloseableSeekableReadWriteHandle.php
+++ b/src/io/CloseableSeekableReadWriteHandle.php
@@ -10,6 +10,11 @@
 
 namespace HH\Lib\Experimental\IO;
 
-interface NonDisposableReadWriteHandle
-  extends ReadWriteHandle, NonDisposableReadHandle, NonDisposableWriteHandle {
+interface CloseableSeekableReadWriteHandle
+  extends
+    SeekableReadWriteHandle,
+    CloseableReadWriteHandle,
+    CloseableSeekableHandle,
+    CloseableSeekableReadHandle,
+    CloseableSeekableWriteHandle {
 }

--- a/src/io/CloseableSeekableWriteHandle.php
+++ b/src/io/CloseableSeekableWriteHandle.php
@@ -10,5 +10,8 @@
 
 namespace HH\Lib\Experimental\IO;
 
-interface NonDisposableReadHandle extends ReadHandle, NonDisposableHandle {
+interface CloseableSeekableWriteHandle extends
+  SeekableWriteHandle,
+  CloseableSeekableHandle,
+  CloseableWriteHandle {
 }

--- a/src/io/CloseableWriteHandle.php
+++ b/src/io/CloseableWriteHandle.php
@@ -10,5 +10,5 @@
 
 namespace HH\Lib\Experimental\IO;
 
-interface NonDisposableWriteHandle extends WriteHandle, NonDisposableHandle {
+interface CloseableWriteHandle extends WriteHandle, CloseableHandle {
 }

--- a/src/io/Handle.php
+++ b/src/io/Handle.php
@@ -19,7 +19,7 @@ use namespace HH\Lib\Experimental\{File, Network};
 <<__Sealed(
   File\Handle::class,
   Network\Socket::class,
-  NonDisposableHandle::class,
+  CloseableHandle::class,
   ReadHandle::class,
   UserspaceHandle::class,
   SeekableHandle::class,

--- a/src/io/_Private/DisposableHandleWrapper.php
+++ b/src/io/_Private/DisposableHandleWrapper.php
@@ -12,7 +12,7 @@ namespace HH\Lib\Experimental\IO\_Private;
 
 use namespace HH\Lib\{Experimental\Fileystem, Experimental\IO, Str};
 
-abstract class DisposableHandleWrapper<T as IO\NonDisposableHandle>
+abstract class DisposableHandleWrapper<T as IO\CloseableHandle>
   implements IO\Handle, \IAsyncDisposable {
   protected function __construct(protected T $impl) {
   }

--- a/src/io/_Private/DisposableReadHandleWrapperTrait.php
+++ b/src/io/_Private/DisposableReadHandleWrapperTrait.php
@@ -12,7 +12,7 @@ namespace HH\Lib\Experimental\IO\_Private;
 
 use namespace HH\Lib\{Experimental\Fileystem, Experimental\IO, Str};
 
-trait DisposableReadHandleWrapperTrait<T as IO\NonDisposableReadHandle>
+trait DisposableReadHandleWrapperTrait<T as IO\CloseableReadHandle>
   implements IO\DisposableReadHandle {
   require implements \IAsyncDisposable;
   require extends DisposableHandleWrapper<T>;

--- a/src/io/_Private/DisposableSeekableHandleWrapperTrait.php
+++ b/src/io/_Private/DisposableSeekableHandleWrapperTrait.php
@@ -12,7 +12,7 @@ namespace HH\Lib\Experimental\IO\_Private;
 
 use namespace HH\Lib\Experimental\IO;
 
-trait DisposableSeekableHandleWrapperTrait<T as IO\NonDisposableSeekableHandle>
+trait DisposableSeekableHandleWrapperTrait<T as IO\CloseableSeekableHandle>
   implements IO\DisposableSeekableHandle {
   require extends DisposableHandleWrapper<T>;
   require implements \IAsyncDisposable;

--- a/src/io/_Private/DisposableWriteHandleWrapperTrait.php
+++ b/src/io/_Private/DisposableWriteHandleWrapperTrait.php
@@ -12,7 +12,7 @@ namespace HH\Lib\Experimental\IO\_Private;
 
 use namespace HH\Lib\{Experimental\Fileystem, Experimental\IO, Str};
 
-trait DisposableWriteHandleWrapperTrait<T as IO\NonDisposableWriteHandle>
+trait DisposableWriteHandleWrapperTrait<T as IO\CloseableWriteHandle>
   implements IO\DisposableWriteHandle {
   require extends DisposableHandleWrapper<T>;
   require implements \IAsyncDisposable;

--- a/src/io/_Private/LegacyPHPResourceHandle.php
+++ b/src/io/_Private/LegacyPHPResourceHandle.php
@@ -13,7 +13,7 @@ namespace HH\Lib\Experimental\IO\_Private;
 use namespace HH\Lib\{Experimental\IO, Str};
 use type HH\Lib\_Private\PHPWarningSuppressor;
 
-abstract class LegacyPHPResourceHandle implements IO\NonDisposableHandle {
+abstract class LegacyPHPResourceHandle implements IO\CloseableHandle {
   protected bool $isAwaitable = true;
   protected function __construct(protected resource $impl) {
     /* HH_IGNORE_ERROR[2049] __PHPStdLib */

--- a/src/io/_Private/PipeReadHandle.php
+++ b/src/io/_Private/PipeReadHandle.php
@@ -14,7 +14,7 @@ use namespace HH\Lib\Experimental\IO;
 
 final class PipeReadHandle
   extends LegacyPHPResourceHandle
-  implements IO\NonDisposableReadHandle {
+  implements IO\CloseableReadHandle {
   use LegacyPHPResourceReadHandleTrait;
   public function __construct(resource $r) {
     parent::__construct($r);

--- a/src/io/_Private/PipeWriteHandle.php
+++ b/src/io/_Private/PipeWriteHandle.php
@@ -14,7 +14,7 @@ use namespace HH\Lib\Experimental\IO;
 
 final class PipeWriteHandle
   extends LegacyPHPResourceHandle
-  implements IO\NonDisposableWriteHandle {
+  implements IO\CloseableWriteHandle {
   use LegacyPHPResourceWriteHandleTrait;
 
   public function __construct(resource $r) {

--- a/src/io/_Private/StdioReadHandle.php
+++ b/src/io/_Private/StdioReadHandle.php
@@ -14,7 +14,7 @@ use namespace HH\Lib\Experimental\IO;
 
 final class StdioReadHandle
   extends LegacyPHPResourceHandle
-  implements IO\NonDisposableReadHandle {
+  implements IO\CloseableReadHandle {
   use LegacyPHPResourceReadHandleTrait;
 
   public function __construct(string $php_uri) {

--- a/src/io/_Private/StdioWriteHandle.php
+++ b/src/io/_Private/StdioWriteHandle.php
@@ -14,7 +14,7 @@ use namespace HH\Lib\Experimental\IO;
 
 final class StdioWriteHandle
   extends LegacyPHPResourceHandle
-  implements IO\NonDisposableWriteHandle {
+  implements IO\CloseableWriteHandle {
   use LegacyPHPResourceWriteHandleTrait;
 
   public function __construct(string $php_uri) {

--- a/src/io/pipe.php
+++ b/src/io/pipe.php
@@ -13,7 +13,7 @@ namespace HH\Lib\Experimental\IO;
 /** Create a pair of handles, where writes to the `WriteHandle` can be
  * read from the `ReadHandle`.
  */
-function pipe_nd(): (NonDisposableReadHandle, NonDisposableWriteHandle) {
+function pipe_nd(): (CloseableReadHandle, CloseableWriteHandle) {
   /* HH_IGNORE_ERROR[2049] intentionally not in HHI */
   /* HH_IGNORE_ERROR[4107] intentionally not in HHI */
   list($r, $w) = \HH\Lib\_Private\Native\pipe() as (resource, resource);

--- a/src/io/stdio.php
+++ b/src/io/stdio.php
@@ -40,13 +40,13 @@ function server_error(): WriteHandle {
  * @see requestOutput
  */
 <<__Memoize>>
-function request_output(): NonDisposableWriteHandle {
+function request_output(): CloseableWriteHandle {
   // php://output has differing eof behavior for interactive stdin - we need
   // the php://stdout for interactive usage (e.g. repls)
   /* HH_IGNORE_ERROR[2049] __PHPStdLib */
   /* HH_IGNORE_ERROR[4107] __PHPStdLib */
   if (\php_sapi_name() === "cli") {
-    return server_output() as NonDisposableWriteHandle;
+    return server_output() as CloseableWriteHandle;
   }
   return new _Private\StdioWriteHandle('php://output');
 }
@@ -60,7 +60,7 @@ function request_output(): NonDisposableWriteHandle {
  *
  * In CLI mode, this is usually the process STDERR.
  */
-function request_error(): ?NonDisposableWriteHandle {
+function request_error(): ?CloseableWriteHandle {
   try {
     return request_errorx();
   } catch (OS\NotFoundException $_) {
@@ -78,7 +78,7 @@ function request_error(): ?NonDisposableWriteHandle {
  *
  * In CLI mode, this is usually the process STDERR.
  */
-function request_errorx(): NonDisposableWriteHandle {
+function request_errorx(): CloseableWriteHandle {
   /* HH_IGNORE_ERROR[2049] __PHPStdLib */
   /* HH_IGNORE_ERROR[4107] __PHPStdLib */
   if (\php_sapi_name() !== "cli") {
@@ -87,7 +87,7 @@ function request_errorx(): NonDisposableWriteHandle {
       "There is no request_error() handle",
     );
   }
-  return server_error() as NonDisposableWriteHandle;
+  return server_error() as CloseableWriteHandle;
 }
 
 /** Return the input handle for the current request.
@@ -96,7 +96,7 @@ function request_errorx(): NonDisposableWriteHandle {
  * POST data, if any.
  */
 <<__Memoize>>
-function request_input(): NonDisposableReadHandle {
+function request_input(): CloseableReadHandle {
   // php://input has differing eof behavior for interactive stdin - we need
   // the php://stdin for interactive usage (e.g. repls)
   /* HH_IGNORE_ERROR[2049] __PHPStdLib */

--- a/src/network/CloseableSocket.php
+++ b/src/network/CloseableSocket.php
@@ -14,9 +14,9 @@ use namespace HH\Lib\Experimental\{IO, TCP, Unix};
 
 <<
   __Sealed(
-    TCP\NonDisposableSocket::class,
-    Unix\NonDisposableSocket::class,
+    TCP\CloseableSocket::class,
+    Unix\CloseableSocket::class,
   ),
 >>
-interface NonDisposableSocket extends Socket, IO\NonDisposableReadWriteHandle {
+interface CloseableSocket extends Socket, IO\CloseableReadWriteHandle {
 }

--- a/src/network/Server.php
+++ b/src/network/Server.php
@@ -13,7 +13,7 @@ namespace HH\Lib\Experimental\Network;
 interface Server<
   TSock as Socket,
   TDSock as TSock as DisposableSocket,
-  TNDSock as TSock as NonDisposableSocket,
+  TNDSock as TSock as CloseableSocket,
 > {
   abstract const type TAddress;
 

--- a/src/network/Socket.php
+++ b/src/network/Socket.php
@@ -14,7 +14,7 @@ use namespace HH\Lib\Experimental\{IO, TCP, Unix};
 
 <<__Sealed(
   DisposableSocket::class,
-  NonDisposableSocket::class,
+  CloseableSocket::class,
   TCP\Socket::class,
   Unix\Socket::class,
 )>>

--- a/src/tcp/CloseableSocket.php
+++ b/src/tcp/CloseableSocket.php
@@ -8,8 +8,11 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\Experimental\TCP;
 
-interface NonDisposableSeekableHandle
-  extends SeekableHandle, NonDisposableHandle {
+use namespace HH\Lib\Experimental\Network;
+
+<<__Sealed(_Private\CloseableTCPSocket::class)>>
+interface CloseableSocket
+  extends Socket, Network\CloseableSocket {
 }

--- a/src/tcp/Server.php
+++ b/src/tcp/Server.php
@@ -13,7 +13,7 @@ namespace HH\Lib\Experimental\TCP;
 use namespace HH\Lib\Experimental\Network;
 
 final class Server
-  implements Network\Server<Socket, DisposableSocket, NonDisposableSocket> {
+  implements Network\Server<Socket, DisposableSocket, CloseableSocket> {
   const type TAddress = (string, int);
 
   private function __construct(private resource $impl) {
@@ -47,9 +47,9 @@ final class Server
     return new _Private\DisposableTCPSocket(await $this->nextConnectionNDAsync());
   }
 
-  public async function nextConnectionNDAsync(): Awaitable<NonDisposableSocket> {
+  public async function nextConnectionNDAsync(): Awaitable<CloseableSocket> {
     return await Network\_Private\socket_accept_async($this->impl)
-      |> new _Private\NonDisposableTCPSocket($$);
+      |> new _Private\CloseableTCPSocket($$);
   }
 
   public function getLocalAddress(): (string, int) {

--- a/src/tcp/Socket.php
+++ b/src/tcp/Socket.php
@@ -12,7 +12,7 @@ namespace HH\Lib\Experimental\TCP;
 
 use namespace HH\Lib\Experimental\{IO, Network};
 
-<<__Sealed(DisposableSocket::class, NonDisposableSocket::class)>>
+<<__Sealed(DisposableSocket::class, CloseableSocket::class)>>
 interface Socket extends Network\Socket {
   /** A host and port number */
   const type TAddress = (string, int);

--- a/src/tcp/_Private/CloseableTCPSocket.php
+++ b/src/tcp/_Private/CloseableTCPSocket.php
@@ -12,9 +12,9 @@ namespace HH\Lib\Experimental\TCP\_Private;
 
 use namespace HH\Lib\Experimental\{IO, Network, TCP};
 
-final class NonDisposableTCPSocket
+final class CloseableTCPSocket
   extends IO\_Private\LegacyPHPResourceHandle
-  implements TCP\NonDisposableSocket, IO\NonDisposableReadWriteHandle {
+  implements TCP\CloseableSocket, IO\CloseableReadWriteHandle {
   use IO\_Private\LegacyPHPResourceReadHandleTrait;
   use IO\_Private\LegacyPHPResourceWriteHandleTrait;
 

--- a/src/tcp/_Private/DisposableTCPSocket.php
+++ b/src/tcp/_Private/DisposableTCPSocket.php
@@ -13,16 +13,16 @@ namespace HH\Lib\Experimental\TCP\_Private;
 use namespace HH\Lib\Experimental\{IO, TCP};
 
 final class DisposableTCPSocket
-  extends IO\_Private\DisposableHandleWrapper<TCP\NonDisposableSocket>
+  extends IO\_Private\DisposableHandleWrapper<TCP\CloseableSocket>
   implements
     \IAsyncDisposable,
     IO\DisposableReadWriteHandle,
     TCP\DisposableSocket {
 
-  use IO\_Private\DisposableReadHandleWrapperTrait<TCP\NonDisposableSocket>;
-  use IO\_Private\DisposableWriteHandleWrapperTrait<TCP\NonDisposableSocket>;
+  use IO\_Private\DisposableReadHandleWrapperTrait<TCP\CloseableSocket>;
+  use IO\_Private\DisposableWriteHandleWrapperTrait<TCP\CloseableSocket>;
 
-  public function __construct(TCP\NonDisposableSocket $impl) {
+  public function __construct(TCP\CloseableSocket $impl) {
     parent::__construct($impl);
   }
 

--- a/src/tcp/connect.php
+++ b/src/tcp/connect.php
@@ -21,7 +21,7 @@ async function connect_nd_async(
   string $host,
   int $port,
   ConnectOptions $opts = shape(),
-): Awaitable<NonDisposableSocket> {
+): Awaitable<CloseableSocket> {
   $ipver = $opts['ip_version'] ?? Network\IPProtocolBehavior::PREFER_IPV6;
   $timeout = $opts['timeout'] ?? null;
   switch ($ipver) {
@@ -61,7 +61,7 @@ async function connect_nd_async(
     if ($sock is resource) {
       $err = await Network\_Private\socket_connect_async($sock, $host, $port, $timeout);
       if ($err === 0) {
-        return new namespace\_Private\NonDisposableTCPSocket($sock);
+        return new namespace\_Private\CloseableTCPSocket($sock);
       }
       $err_message = 'connect() failed';
     }

--- a/src/unix/CloseableSocket.php
+++ b/src/unix/CloseableSocket.php
@@ -8,8 +8,10 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\Experimental\Unix;
 
-interface NonDisposableHandle extends Handle {
-  public function closeAsync(): Awaitable<void>;
+use namespace HH\Lib\Experimental\Network;
+
+<<__Sealed(_Private\CloseableSocket::class)>>
+interface CloseableSocket extends Socket, Network\CloseableSocket {
 }

--- a/src/unix/Server.php
+++ b/src/unix/Server.php
@@ -13,7 +13,7 @@ namespace HH\Lib\Experimental\Unix;
 use namespace HH\Lib\Experimental\Network;
 
 final class Server
-  implements Network\Server<Socket, DisposableSocket, NonDisposableSocket> {
+  implements Network\Server<Socket, DisposableSocket, CloseableSocket> {
   const type TAddress = string;
 
   private function __construct(private resource $impl) {
@@ -35,9 +35,9 @@ final class Server
     return new _Private\DisposableSocket(await $this->nextConnectionNDAsync());
   }
 
-  public async function nextConnectionNDAsync(): Awaitable<NonDisposableSocket> {
+  public async function nextConnectionNDAsync(): Awaitable<CloseableSocket> {
     return await Network\_Private\socket_accept_async($this->impl)
-      |> new _Private\NonDisposableSocket($$);
+      |> new _Private\CloseableSocket($$);
   }
 
   public function getLocalAddress(): string {

--- a/src/unix/Socket.php
+++ b/src/unix/Socket.php
@@ -12,7 +12,7 @@ namespace HH\Lib\Experimental\Unix;
 
 use namespace HH\Lib\Experimental\{IO, Network};
 
-<<__Sealed(DisposableSocket::class, NonDisposableSocket::class)>>
+<<__Sealed(DisposableSocket::class, CloseableSocket::class)>>
 interface Socket extends Network\Socket {
   /** A file path */
   const type TAddress = string;

--- a/src/unix/_Private/CloseableSocket.php
+++ b/src/unix/_Private/CloseableSocket.php
@@ -12,9 +12,9 @@ namespace HH\Lib\Experimental\Unix\_Private;
 
 use namespace HH\Lib\Experimental\{IO, Network, Unix};
 
-final class NonDisposableSocket
+final class CloseableSocket
   extends IO\_Private\LegacyPHPResourceHandle
-  implements Unix\NonDisposableSocket, IO\NonDisposableReadWriteHandle {
+  implements Unix\CloseableSocket, IO\CloseableReadWriteHandle {
   use IO\_Private\LegacyPHPResourceReadHandleTrait;
   use IO\_Private\LegacyPHPResourceWriteHandleTrait;
 

--- a/src/unix/_Private/DisposableSocket.php
+++ b/src/unix/_Private/DisposableSocket.php
@@ -13,20 +13,20 @@ namespace HH\Lib\Experimental\Unix\_Private;
 use namespace HH\Lib\Experimental\{IO, Unix};
 
 final class DisposableSocket
-  extends IO\_Private\DisposableHandleWrapper<Unix\NonDisposableSocket>
+  extends IO\_Private\DisposableHandleWrapper<Unix\CloseableSocket>
   implements
     \IAsyncDisposable,
     IO\DisposableReadWriteHandle,
     Unix\DisposableSocket {
 
   use IO\_Private\DisposableReadHandleWrapperTrait<
-    Unix\NonDisposableSocket,
+    Unix\CloseableSocket,
   >;
   use IO\_Private\DisposableWriteHandleWrapperTrait<
-    Unix\NonDisposableSocket,
+    Unix\CloseableSocket,
   >;
 
-  public function __construct(Unix\NonDisposableSocket $impl) {
+  public function __construct(Unix\CloseableSocket $impl) {
     parent::__construct($impl);
   }
 

--- a/src/unix/connect.php
+++ b/src/unix/connect.php
@@ -15,7 +15,7 @@ use namespace HH\Lib\Experimental\Network;
 async function connect_nd_async(
   string $path,
   ConnectOptions $opts = shape(),
-): Awaitable<NonDisposableSocket> {
+): Awaitable<CloseableSocket> {
   /* HH_IGNORE_ERROR[2049] PHP STDLib */
   /* HH_IGNORE_ERROR[4107] PHP STDLib */
   $sock = \socket_create(\AF_UNIX, \SOCK_STREAM, 0);
@@ -29,7 +29,7 @@ async function connect_nd_async(
       $opts['timeout'] ?? null,
     );
     if ($err === 0) {
-      return new _Private\NonDisposableSocket($sock);
+      return new _Private\CloseableSocket($sock);
     }
   } else {
     /* HH_IGNORE_ERROR[2049] PHP STDLib */


### PR DESCRIPTION
If you don't need to store a handle, the correct approach is:

```
function foo(<<__AcceptDisposable>> FooHandle $handle): void {}
```

If you /do/ need to store it, this looks correct:

```
function foo(NonDisposableFooHandle $handle): void {}
```

... but it isn't. Instead, do this:

```
function foo(FooHandle $handle): void {}
```

The lack of `<<__AcceptDisposable>>` is enough to ban disposables.

Currently, the only reason to care about the `NonDisposable` interfaces
is if you want to call `genClose()` aka `closeAsync()`; let's make that
verbatim.

This matters for handles like `IO\server_error()` which implement
`IO\WriteHandle`, but **do not** implement either
`IO\DisposableWriteHandle` or `IO\NonDisposableWriteHandle` as it
can't be closed by a specific request.