### PR TITLE
IO/OS: Rename private namespaces for consistency with new builtins

### DIFF
--- a/src/file/_Private/CloseableFileHandle.php
+++ b/src/file/_Private/CloseableFileHandle.php
@@ -8,17 +8,18 @@
  *
  */
 
-namespace HH\Lib\Experimental\File\_Private;
+namespace HH\Lib\_Private\_File;
 
 use namespace HH\Lib\Str;
+use namespace HH\Lib\_Private\{_IO, _OS};
 use namespace HH\Lib\Experimental\{IO, File, OS};
 use type HH\Lib\_Private\PHPWarningSuppressor;
 
 <<__ConsistentConstruct>>
 abstract class CloseableFileHandle
-  extends IO\_Private\LegacyPHPResourceHandle
+  extends _IO\LegacyPHPResourceHandle
   implements File\Handle, IO\CloseableHandle {
-  use IO\_Private\LegacyPHPResourceSeekableHandleTrait;
+  use _IO\LegacyPHPResourceSeekableHandleTrait;
 
   protected string $filename;
 
@@ -31,7 +32,7 @@ abstract class CloseableFileHandle
     /* HH_IGNORE_ERROR[4107] PHPStdLib */
     $errno = \posix_get_last_error() as int;
     if ($f === false) {
-      OS\_Private\throw_errno($errno, 'fopen');
+      _OS\throw_errno($errno, 'fopen');
     }
     $this->filename = $path;
     parent::__construct($f);
@@ -61,7 +62,7 @@ abstract class CloseableFileHandle
     if ($success) {
       return new File\Lock($impl);
     }
-    OS\_Private\throw_errno($errno as int, 'flock');
+    _OS\throw_errno($errno as int, 'flock');
   }
 
   <<__ReturnDisposable>>
@@ -80,7 +81,7 @@ abstract class CloseableFileHandle
     if ($would_block) {
       throw new File\AlreadyLockedException();
     }
-    OS\_Private\throw_errno($errno as int, 'flock');
+    _OS\throw_errno($errno as int, 'flock');
   }
 
 

--- a/src/file/_Private/CloseableReadHandle.php
+++ b/src/file/_Private/CloseableReadHandle.php
@@ -8,12 +8,13 @@
  *
  */
 
-namespace HH\Lib\Experimental\File\_Private;
+namespace HH\Lib\_Private\_File;
 
 use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\_Private\_IO;
 
 final class CloseableReadHandle
   extends CloseableFileHandle
   implements File\CloseableReadHandle {
-  use IO\_Private\LegacyPHPResourceReadHandleTrait;
+  use _IO\LegacyPHPResourceReadHandleTrait;
 }

--- a/src/file/_Private/CloseableReadWriteHandle.php
+++ b/src/file/_Private/CloseableReadWriteHandle.php
@@ -8,13 +8,14 @@
  *
  */
 
-namespace HH\Lib\Experimental\File\_Private;
+namespace HH\Lib\_Private\_File;
 
 use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\_Private\_IO;
 
 final class CloseableReadWriteHandle
   extends CloseableFileHandle
   implements File\CloseableReadWriteHandle {
-  use IO\_Private\LegacyPHPResourceReadHandleTrait;
-  use IO\_Private\LegacyPHPResourceWriteHandleTrait;
+  use _IO\LegacyPHPResourceReadHandleTrait;
+  use _IO\LegacyPHPResourceWriteHandleTrait;
 }

--- a/src/file/_Private/CloseableWriteHandle.php
+++ b/src/file/_Private/CloseableWriteHandle.php
@@ -8,12 +8,13 @@
  *
  */
 
-namespace HH\Lib\Experimental\File\_Private;
+namespace HH\Lib\_Private\_File;
 
 use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\_Private\_IO;
 
 final class CloseableWriteHandle
   extends CloseableFileHandle
   implements File\CloseableWriteHandle {
-  use IO\_Private\LegacyPHPResourceWriteHandleTrait;
+  use _IO\LegacyPHPResourceWriteHandleTrait;
 }

--- a/src/file/_Private/DisposableFileHandle.php
+++ b/src/file/_Private/DisposableFileHandle.php
@@ -8,13 +8,14 @@
  *
  */
 
-namespace HH\Lib\Experimental\File\_Private;
+namespace HH\Lib\_Private\_File;
 
 use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\_Private\_IO;
 
 <<__ConsistentConstruct>>
 abstract class DisposableFileHandle<T as File\CloseableHandle>
-  extends IO\_Private\DisposableHandleWrapper<T>
+  extends _IO\DisposableHandleWrapper<T>
   implements File\Handle {
   final public function __construct(T $impl) {
     parent::__construct($impl);

--- a/src/file/_Private/DisposableFileReadHandle.php
+++ b/src/file/_Private/DisposableFileReadHandle.php
@@ -8,12 +8,13 @@
  *
  */
 
-namespace HH\Lib\Experimental\File\_Private;
+namespace HH\Lib\_Private\_File;
 
 use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\_Private\_IO;
 
 final class DisposableFileReadHandle
   extends DisposableFileHandle<File\CloseableReadHandle>
   implements File\DisposableReadHandle {
-  use IO\_Private\DisposableReadHandleWrapperTrait<File\CloseableReadHandle>;
+  use _IO\DisposableReadHandleWrapperTrait<File\CloseableReadHandle>;
 }

--- a/src/file/_Private/DisposableFileReadWriteHandle.php
+++ b/src/file/_Private/DisposableFileReadWriteHandle.php
@@ -8,13 +8,14 @@
  *
  */
 
-namespace HH\Lib\Experimental\File\_Private;
+namespace HH\Lib\_Private\_File;
 
 use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\_Private\_IO;
 
 final class DisposableFileReadWriteHandle
   extends DisposableFileHandle<File\CloseableReadWriteHandle>
   implements File\DisposableReadWriteHandle {
-  use IO\_Private\DisposableReadHandleWrapperTrait<File\CloseableReadWriteHandle>;
-  use IO\_Private\DisposableWriteHandleWrapperTrait<File\CloseableReadWriteHandle>;
+  use _IO\DisposableReadHandleWrapperTrait<File\CloseableReadWriteHandle>;
+  use _IO\DisposableWriteHandleWrapperTrait<File\CloseableReadWriteHandle>;
 }

--- a/src/file/_Private/DisposableFileWriteHandle.php
+++ b/src/file/_Private/DisposableFileWriteHandle.php
@@ -8,12 +8,13 @@
  *
  */
 
-namespace HH\Lib\Experimental\File\_Private;
+namespace HH\Lib\_Private\_File;
 
 use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\_Private\_IO;
 
 final class DisposableFileWriteHandle
   extends DisposableFileHandle<File\CloseableWriteHandle>
   implements File\DisposableWriteHandle {
-  use IO\_Private\DisposableWriteHandleWrapperTrait<File\CloseableWriteHandle>;
+  use _IO\DisposableWriteHandleWrapperTrait<File\CloseableWriteHandle>;
 }

--- a/src/file/_Private/TemporaryFile.php
+++ b/src/file/_Private/TemporaryFile.php
@@ -8,15 +8,16 @@
  *
  */
 
-namespace HH\Lib\Experimental\File\_Private;
+namespace HH\Lib\_Private\_File;
 
 use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\_Private\_IO;
 
 final class TemporaryFile
   extends DisposableFileHandle<File\CloseableReadWriteHandle>
   implements File\DisposableReadWriteHandle {
-  use IO\_Private\DisposableReadHandleWrapperTrait<File\CloseableReadWriteHandle>;
-  use IO\_Private\DisposableWriteHandleWrapperTrait<File\CloseableReadWriteHandle>;
+  use _IO\DisposableReadHandleWrapperTrait<File\CloseableReadWriteHandle>;
+  use _IO\DisposableWriteHandleWrapperTrait<File\CloseableReadWriteHandle>;
 
   public async function __disposeAsync(): Awaitable<void> {
     await parent::__disposeAsync();

--- a/src/file/open.php
+++ b/src/file/open.php
@@ -9,23 +9,24 @@
  */
 
 namespace HH\Lib\Experimental\File;
+use namespace HH\Lib\_Private\_File;
 
 function open_read_only_nd(string $path): CloseableReadHandle {
-  return new _Private\CloseableReadHandle($path, 'rb');
+  return new _File\CloseableReadHandle($path, 'rb');
 }
 
 function open_write_only_nd(
   string $path,
   WriteMode $mode = WriteMode::OPEN_OR_CREATE,
 ): CloseableWriteHandle {
-  return new _Private\CloseableWriteHandle($path, $mode as string);
+  return new _File\CloseableWriteHandle($path, $mode as string);
 }
 
 function open_read_write_nd(
   string $path,
   WriteMode $mode = WriteMode::OPEN_OR_CREATE,
 ): CloseableReadWriteHandle {
-  return new _Private\CloseableReadWriteHandle(
+  return new _File\CloseableReadWriteHandle(
     $path,
     ($mode as string).'+',
   );
@@ -33,7 +34,7 @@ function open_read_write_nd(
 
 <<__ReturnDisposable>>
 function open_read_only(string $path): DisposableReadHandle {
-  return new _Private\DisposableFileReadHandle(open_read_only_nd($path));
+  return new _File\DisposableFileReadHandle(open_read_only_nd($path));
 }
 
 <<__ReturnDisposable>>
@@ -41,7 +42,7 @@ function open_write_only(
   string $path,
   WriteMode $mode = WriteMode::OPEN_OR_CREATE,
 ): DisposableWriteHandle {
-  return new _Private\DisposableFileWriteHandle(
+  return new _File\DisposableFileWriteHandle(
     open_write_only_nd($path, $mode),
   );
 }
@@ -51,7 +52,7 @@ function open_read_write(
   string $path,
   WriteMode $mode = WriteMode::OPEN_OR_CREATE,
 ): DisposableReadWriteHandle {
-  return new _Private\DisposableFileReadWriteHandle(
+  return new _File\DisposableFileReadWriteHandle(
     open_read_write_nd($path, $mode),
   );
 }

--- a/src/file/temporary_file.php
+++ b/src/file/temporary_file.php
@@ -9,13 +9,14 @@
  */
 
 namespace HH\Lib\Experimental\File;
+use namespace HH\Lib\_Private\_File;
 
 <<__ReturnDisposable>>
 function temporary_file(): DisposableReadWriteHandle {
   /* HH_IGNORE_ERROR[2049] PHP stdlib */
   /* HH_IGNORE_ERROR[4107] PHP stdlib */
   $path = \sys_get_temp_dir().'/'.\bin2hex(\random_bytes(8));
-  return new _Private\TemporaryFile(
+  return new _File\TemporaryFile(
     open_read_write_nd($path, WriteMode::MUST_CREATE),
   );
 }

--- a/src/io/_Private/DisposableHandleWrapper.php
+++ b/src/io/_Private/DisposableHandleWrapper.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO\_Private;
+namespace HH\Lib\_Private\_IO;
 
 use namespace HH\Lib\{Experimental\Fileystem, Experimental\IO, Str};
 

--- a/src/io/_Private/DisposableReadHandleWrapperTrait.php
+++ b/src/io/_Private/DisposableReadHandleWrapperTrait.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO\_Private;
+namespace HH\Lib\_Private\_IO;
 
 use namespace HH\Lib\{Experimental\Fileystem, Experimental\IO, Str};
 

--- a/src/io/_Private/DisposableSeekableHandleWrapperTrait.php
+++ b/src/io/_Private/DisposableSeekableHandleWrapperTrait.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO\_Private;
+namespace HH\Lib\_Private\_IO;
 
 use namespace HH\Lib\Experimental\IO;
 

--- a/src/io/_Private/DisposableWriteHandleWrapperTrait.php
+++ b/src/io/_Private/DisposableWriteHandleWrapperTrait.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO\_Private;
+namespace HH\Lib\_Private\_IO;
 
 use namespace HH\Lib\{Experimental\Fileystem, Experimental\IO, Str};
 

--- a/src/io/_Private/LegacyPHPResourceHandle.php
+++ b/src/io/_Private/LegacyPHPResourceHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO\_Private;
+namespace HH\Lib\_Private\_IO;
 
 use namespace HH\Lib\{Experimental\IO, Str};
 use type HH\Lib\_Private\PHPWarningSuppressor;

--- a/src/io/_Private/LegacyPHPResourceReadHandleTrait.php
+++ b/src/io/_Private/LegacyPHPResourceReadHandleTrait.php
@@ -8,10 +8,11 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO\_Private;
+namespace HH\Lib\_Private\_IO;
 
 use namespace HH\Lib\Str;
 use namespace HH\Lib\Experimental\{IO, OS};
+use namespace HH\Lib\_Private\_OS;
 use type HH\Lib\_Private\PHPWarningSuppressor;
 
 trait LegacyPHPResourceReadHandleTrait implements IO\ReadHandle {
@@ -32,7 +33,7 @@ trait LegacyPHPResourceReadHandleTrait implements IO\ReadHandle {
     /* HH_IGNORE_ERROR[4107] __PHPStdLib */
     $errno = \posix_get_last_error();
     if ($result === false) {
-      OS\_Private\throw_errno($errno as int, 'stream_get_contents');
+      _OS\throw_errno($errno as int, 'stream_get_contents');
     }
     return $result as string;
   }
@@ -64,7 +65,7 @@ trait LegacyPHPResourceReadHandleTrait implements IO\ReadHandle {
         $now = \microtime(true);
         $timeout_seconds -= ($now - $start);
         if ($timeout_seconds < 0) {
-          OS\_Private\throw_errorcode(OS\ErrorCode::ETIMEDOUT, __METHOD__);
+          _OS\throw_errorcode(OS\ErrorCode::ETIMEDOUT, __METHOD__);
         }
         $start = $now;
       }
@@ -110,7 +111,7 @@ trait LegacyPHPResourceReadHandleTrait implements IO\ReadHandle {
         $now = \microtime(true);
         $timeout_seconds -= ($now - $start);
         if ($timeout_seconds < 0.0) {
-          OS\_Private\throw_errorcode(OS\ErrorCode::ETIMEDOUT, __METHOD__);
+          _OS\throw_errorcode(OS\ErrorCode::ETIMEDOUT, __METHOD__);
         }
         $start = $now;
       }

--- a/src/io/_Private/LegacyPHPResourceSeekableHandleTrait.php
+++ b/src/io/_Private/LegacyPHPResourceSeekableHandleTrait.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO\_Private;
+namespace HH\Lib\_Private\_IO;
 
 use namespace HH\Lib\{Experimental\IO, Str};
 use type HH\Lib\_Private\PHPWarningSuppressor;

--- a/src/io/_Private/LegacyPHPResourceWriteHandleTrait.php
+++ b/src/io/_Private/LegacyPHPResourceWriteHandleTrait.php
@@ -8,9 +8,10 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO\_Private;
+namespace HH\Lib\_Private\_IO;
 
 use namespace HH\Lib\Str;
+use namespace HH\Lib\_Private\_OS;
 use namespace HH\Lib\Experimental\{IO, OS};
 use type HH\Lib\_Private\PHPWarningSuppressor;
 
@@ -26,7 +27,7 @@ trait LegacyPHPResourceWriteHandleTrait implements IO\WriteHandle {
     /* HH_IGNORE_ERROR[4107] __PHPStdLib */
     $errno = \posix_get_last_error();
     if ($result === false) {
-      OS\_Private\throw_errno($errno, 'fwrite');
+      _OS\throw_errno($errno, 'fwrite');
     }
     return $result as int;
   }
@@ -51,7 +52,7 @@ trait LegacyPHPResourceWriteHandleTrait implements IO\WriteHandle {
           $now = \microtime(true);
           $timeout_seconds -= ($now - $start);
           if ($timeout_seconds < 0.0) {
-            OS\_Private\throw_errorcode(OS\ErrorCode::ETIMEDOUT, __METHOD__);
+            _OS\throw_errorcode(OS\ErrorCode::ETIMEDOUT, __METHOD__);
           }
           $start = $now;
         }

--- a/src/io/_Private/PipeReadHandle.php
+++ b/src/io/_Private/PipeReadHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO\_Private;
+namespace HH\Lib\_Private\_IO;
 
 use namespace HH\Lib\Experimental\IO;
 

--- a/src/io/_Private/PipeWriteHandle.php
+++ b/src/io/_Private/PipeWriteHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO\_Private;
+namespace HH\Lib\_Private\_IO;
 
 use namespace HH\Lib\Experimental\IO;
 

--- a/src/io/_Private/StdioReadHandle.php
+++ b/src/io/_Private/StdioReadHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO\_Private;
+namespace HH\Lib\_Private\_IO;
 
 use namespace HH\Lib\Experimental\IO;
 

--- a/src/io/_Private/StdioWriteHandle.php
+++ b/src/io/_Private/StdioWriteHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO\_Private;
+namespace HH\Lib\_Private\_IO;
 
 use namespace HH\Lib\Experimental\IO;
 

--- a/src/io/pipe.php
+++ b/src/io/pipe.php
@@ -10,6 +10,8 @@
 
 namespace HH\Lib\Experimental\IO;
 
+use namespace HH\Lib\_Private\_IO;
+
 /** Create a pair of handles, where writes to the `WriteHandle` can be
  * read from the `ReadHandle`.
  *
@@ -20,7 +22,7 @@ function pipe_nd(): (CloseableReadHandle, CloseableWriteHandle) {
   /* HH_IGNORE_ERROR[4107] intentionally not in HHI */
   list($r, $w) = \HH\Lib\_Private\Native\pipe() as (resource, resource);
   return tuple(
-    new _Private\PipeReadHandle($r),
-    new _Private\PipeWriteHandle($w),
+    new _IO\PipeReadHandle($r),
+    new _IO\PipeWriteHandle($w),
   );
 }

--- a/src/io/stdio.php
+++ b/src/io/stdio.php
@@ -11,6 +11,7 @@
 namespace HH\Lib\Experimental\IO;
 
 use namespace HH\Lib\Experimental\OS;
+use namespace HH\Lib\_Private\{_IO, _OS};
 
 /** Return STDOUT for the server process.
  *
@@ -20,7 +21,7 @@ use namespace HH\Lib\Experimental\OS;
  */
 <<__Memoize>>
 function server_output(): WriteHandle {
-  return new _Private\StdioWriteHandle('php://stdout');
+  return new _IO\StdioWriteHandle('php://stdout');
 }
 
 /** Return STDERR for the server process.
@@ -29,7 +30,7 @@ function server_output(): WriteHandle {
  */
 <<__Memoize>>
 function server_error(): WriteHandle {
-  return new _Private\StdioWriteHandle('php://stderr');
+  return new _IO\StdioWriteHandle('php://stderr');
 }
 
 /** Return the output handle for the current request.
@@ -48,7 +49,7 @@ function request_output(): CloseableWriteHandle {
   if (\php_sapi_name() === "cli") {
     return server_output() as CloseableWriteHandle;
   }
-  return new _Private\StdioWriteHandle('php://output');
+  return new _IO\StdioWriteHandle('php://output');
 }
 
 /** Return the error output handle for the current request.
@@ -82,8 +83,8 @@ function request_errorx(): CloseableWriteHandle {
   /* HH_IGNORE_ERROR[2049] __PHPStdLib */
   /* HH_IGNORE_ERROR[4107] __PHPStdLib */
   if (\php_sapi_name() !== "cli") {
-    OS\_Private\throw_errno(
-      OS\_Private\Errno::ENOENT,
+    _OS\throw_errno(
+      _OS\Errno::ENOENT,
       "There is no request_error() handle",
     );
   }
@@ -102,7 +103,7 @@ function request_input(): CloseableReadHandle {
   /* HH_IGNORE_ERROR[2049] __PHPStdLib */
   /* HH_IGNORE_ERROR[4107] __PHPStdLib */
   if (\php_sapi_name() === "cli") {
-    return new _Private\StdioReadHandle('php://stdin');
+    return new _IO\StdioReadHandle('php://stdin');
   }
-  return new _Private\StdioReadHandle('php://input');
+  return new _IO\StdioReadHandle('php://input');
 }

--- a/src/network/_Private/get_peer_name.php
+++ b/src/network/_Private/get_peer_name.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\Network\_Private;
+namespace HH\Lib\_Private\_Network;
 
-use type HH\Lib\Experimental\OS\_Private\Errno;
+use namespace HH\Lib\_Private\_OS;
 
 function get_peer_name(resource $sock): (string, int) {
   $addr = '';
@@ -28,7 +28,7 @@ function get_peer_name(resource $sock): (string, int) {
   /* HH_IGNORE_ERROR[4107] PHPStdLib */
   $err = \socket_last_error($sock) as int;
   throw_socket_error(
-    $err === 0 ? Errno::EAFNOSUPPORT as int : $err,
+    $err === 0 ? _OS\Errno::EAFNOSUPPORT as int : $err,
     'retrieving peer address',
   );
 }

--- a/src/network/_Private/get_sock_name.php
+++ b/src/network/_Private/get_sock_name.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\Network\_Private;
+namespace HH\Lib\_Private\_Network;
 
-use type HH\Lib\Experimental\OS\_Private\Errno;
+use namespace HH\Lib\_Private\_OS;
 
 function get_sock_name(resource $sock): (string, int) {
   $addr = '';
@@ -28,7 +28,7 @@ function get_sock_name(resource $sock): (string, int) {
   /* HH_IGNORE_ERROR[4107] PHPStdLib */
   $err = \socket_last_error($sock) as int;
   throw_socket_error(
-    $err === 0 ? Errno::EAFNOSUPPORT as int : $err,
+    $err === 0 ? _OS\Errno::EAFNOSUPPORT as int : $err,
     'retrieving local address',
   );
 }

--- a/src/network/_Private/maybe_throw_socket_error.php
+++ b/src/network/_Private/maybe_throw_socket_error.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\Network\_Private;
+namespace HH\Lib\_Private\_Network;
 
 function maybe_throw_socket_error(int $php_socket_error, string $message): void {
   if ($php_socket_error === 0) {

--- a/src/network/_Private/set_socket_options.php
+++ b/src/network/_Private/set_socket_options.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\Network\_Private;
+namespace HH\Lib\_Private\_Network;
 
 use type HH\Lib\Experimental\Network\SocketOptions;
 

--- a/src/network/_Private/socket_accept_async.php
+++ b/src/network/_Private/socket_accept_async.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\Network\_Private;
+namespace HH\Lib\_Private\_Network;
 
-use type HH\Lib\Experimental\OS\_Private\Errno;
+use namespace HH\Lib\_Private\_OS;
 use type HH\Lib\_Private\PHPWarningSuppressor;
 
 async function socket_accept_async(resource $server): Awaitable<resource> {
@@ -31,7 +31,7 @@ async function socket_accept_async(resource $server): Awaitable<resource> {
     /* HH_IGNORE_ERROR[2049] PHP stdlib */
     /* HH_IGNORE_ERROR[4107] PHP stdlib */
     $err = \socket_last_error($server) as int;
-    if ($retry === false || ($err !== 0 && $err !== Errno::EAGAIN)) {
+    if ($retry === false || ($err !== 0 && $err !== _OS\Errno::EAGAIN)) {
       throw_socket_error($err, "accept() failed");
     }
     // accept (3P) defines select() as indicating the FD ready for read when there's a connection

--- a/src/network/_Private/socket_connect_async.php
+++ b/src/network/_Private/socket_connect_async.php
@@ -8,10 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\Network\_Private;
+namespace HH\Lib\_Private\_Network;
 
-use const HH\Lib\Experimental\OS\_Private\IS_MACOS;
-use type HH\Lib\Experimental\OS\_Private\Errno;
+use namespace HH\Lib\_Private\_OS;
 use type HH\Lib\_Private\PHPWarningSuppressor;
 
 /** Asynchronously connect to a socket.
@@ -42,6 +41,7 @@ async function socket_connect_async(
   if ($res === true) {
     return 0;
   }
+
   if ($err === 0) {
     // $res == false && $err === 0 means that HHVM's `socket_connect()`
     // function did not call the POSIX `connect()` function, because of an
@@ -69,11 +69,10 @@ async function socket_connect_async(
     //   printf("Error: %d\n", errno);
     // }
     // ```
-    return (IS_MACOS ? Errno::EADDRNOTAVAIL : Errno::ECONNREFUSED) as int;
+    return (_OS\IS_MACOS ? _OS\Errno::EADDRNOTAVAIL : _OS\Errno::ECONNREFUSED) as int;
   }
-  /* HH_IGNORE_ERROR[2049] PHP stdlib */
-  /* HH_IGNORE_ERROR[4107] PHP stdlib */
-  if ($err !== Errno::EINPROGRESS) {
+
+  if ($err !== _OS\Errno::EINPROGRESS) {
     return $err;
   }
   /* HH_IGNORE_ERROR[2049] PHP stdlib */
@@ -86,13 +85,13 @@ async function socket_connect_async(
   /* HH_IGNORE_ERROR[4107] PHP stdlib */
   $res = await \stream_await($sock, \STREAM_AWAIT_WRITE, $timeout_seconds ?? 0.0);
   if ($res === \STREAM_AWAIT_CLOSED) {
-    return Errno::ECONNRESET as int;
+    return _OS\Errno::ECONNRESET as int;
   }
   if ($res === \STREAM_AWAIT_TIMEOUT) {
     /* HH_IGNORE_ERROR[2049] PHP stdlib */
     /* HH_IGNORE_ERROR[4107] PHP stdlib */
     \fclose($sock);
-    return Errno::ETIMEDOUT as int;
+    return _OS\Errno::ETIMEDOUT as int;
   }
   // \socket_last_error() is not populated by async socket failures: it's
   // effectively a cache of the C errno constant after the last socket_*

--- a/src/network/_Private/socket_create_bind_listen_async.php
+++ b/src/network/_Private/socket_create_bind_listen_async.php
@@ -8,10 +8,10 @@
  *
  */
 
-namespace HH\Lib\Experimental\Network\_Private;
+namespace HH\Lib\_Private\_Network;
 
 use namespace HH\Lib\Experimental\Network;
-use type HH\Lib\Experimental\OS\_Private\Errno;
+use namespace HH\Lib\_Private\_OS;
 use type HH\Lib\_Private\PHPWarningSuppressor;
 
 async function socket_create_bind_listen_async(
@@ -43,14 +43,14 @@ async function socket_create_bind_listen_async(
     /* HH_IGNORE_ERROR[2049] PHPStdLib */
     /* HH_IGNORE_ERROR[4107] PHPStdLib */
     $err = \socket_last_error($sock) as int;
-    if ($err !== Errno::EINPROGRESS) {
+    if ($err !== _OS\Errno::EINPROGRESS) {
       throw_socket_error($err, 'bind() failed');
     }
   }
   /* HH_IGNORE_ERROR[2049] PHPStdLib */
   /* HH_IGNORE_ERROR[4107] PHPStdLib */
   $err = \socket_last_error($sock) as int;
-  if ($err === Errno::EINPROGRESS) {
+  if ($err === _OS\Errno::EINPROGRESS) {
     /* HH_IGNORE_ERROR[2049] PHPStdLib */
     /* HH_IGNORE_ERROR[4107] PHPStdLib */
     await \stream_await($sock, \STREAM_AWAIT_READ_WRITE);

--- a/src/network/_Private/throw_socket_error.php
+++ b/src/network/_Private/throw_socket_error.php
@@ -8,9 +8,10 @@
  *
  */
 
-namespace HH\Lib\Experimental\Network\_Private;
+namespace HH\Lib\_Private\_Network;
 
 use namespace HH\Lib\Experimental\{IO, Network, OS};
+use namespace HH\Lib\_Private\_OS;
 use namespace HH\Lib\Str;
 
 const int PHP_HERROR_OFFSET = 10000;
@@ -18,9 +19,9 @@ const int PHP_HERROR_OFFSET = 10000;
 function throw_socket_error(int $php_socket_error, string $message): noreturn {
   invariant($php_socket_error !== 0, "%s should not be called on success", __FUNCTION__);
   if ($php_socket_error < 0) {
-    $herror = (-($php_socket_error + PHP_HERROR_OFFSET)) as OS\_Private\HError;
-    $name = 'HERROR_'.OS\_Private\HError::getNames()[$herror];
+    $herror = (-($php_socket_error + PHP_HERROR_OFFSET)) as _OS\HError;
+    $name = 'HERROR_'._OS\HError::getNames()[$herror];
     throw new OS\Exception($name as OS\ErrorCode, $message);
   }
-  OS\_Private\throw_errno($php_socket_error as OS\_Private\Errno, $message);
+  _OS\throw_errno($php_socket_error as _OS\Errno, $message);
 }

--- a/src/os/_Private.php
+++ b/src/os/_Private.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\OS\_Private;
+namespace HH\Lib\_Private\_OS;
 
 use namespace HH\Lib\Experimental\OS;
 

--- a/src/os/_Private/Errno.php
+++ b/src/os/_Private/Errno.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\OS\_Private;
+namespace HH\Lib\_Private\_OS;
 
 use namespace HH\Lib\{C, Str};
 use namespace HH\Lib\Experimental\OS;

--- a/src/os/_Private/GAIError.php
+++ b/src/os/_Private/GAIError.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\OS\_Private;
+namespace HH\Lib\_Private\_OS;
 
 // hackfmt-ignore
 enum GNU_GAIError : int {

--- a/src/os/_Private/HError.php
+++ b/src/os/_Private/HError.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\OS\_Private;
+namespace HH\Lib\_Private\_OS;
 
 use namespace HH\Lib\Experimental\OS;
 

--- a/src/os/_Private/exceptions.php
+++ b/src/os/_Private/exceptions.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\OS\_Private;
+namespace HH\Lib\_Private\_OS;
 
 use namespace HH\Lib\C;
 use namespace HH\Lib\Experimental\OS;

--- a/src/os/exceptions.php
+++ b/src/os/exceptions.php
@@ -11,9 +11,10 @@
 namespace HH\Lib\Experimental\OS;
 
 use namespace HH\Lib\C;
+use namespace HH\Lib\_Private\_OS;
 
 final class ChildProcessException extends Exception {
-  use _Private\ExceptionWithSingleErrorCodeTrait;
+  use _OS\ExceptionWithSingleErrorCodeTrait;
 
   <<__Override>>
   public static function _getValidErrorCode(): ErrorCode {
@@ -25,7 +26,7 @@ abstract class ConnectionException extends Exception {
 }
 
 final class BrokenPipeException extends ConnectionException {
-  use _Private\ExceptionWithMultipleErrorCodesTrait;
+  use _OS\ExceptionWithMultipleErrorCodesTrait;
 
   <<__Override>>
   public static function _getValidErrorCodes(): keyset<ErrorCode> {
@@ -34,7 +35,7 @@ final class BrokenPipeException extends ConnectionException {
 }
 
 final class ConnectionAbortedException extends ConnectionException {
-  use _Private\ExceptionWithSingleErrorCodeTrait;
+  use _OS\ExceptionWithSingleErrorCodeTrait;
 
   <<__Override>>
   public static function _getValidErrorCode(): ErrorCode {
@@ -43,7 +44,7 @@ final class ConnectionAbortedException extends ConnectionException {
 }
 
 final class ConnectionRefusedException extends ConnectionException {
-  use _Private\ExceptionWithSingleErrorCodeTrait;
+  use _OS\ExceptionWithSingleErrorCodeTrait;
 
   <<__Override>>
   public static function _getValidErrorCode(): ErrorCode {
@@ -52,7 +53,7 @@ final class ConnectionRefusedException extends ConnectionException {
 }
 
 final class ConnectionResetException extends ConnectionException {
-  use _Private\ExceptionWithSingleErrorCodeTrait;
+  use _OS\ExceptionWithSingleErrorCodeTrait;
 
   <<__Override>>
   public static function _getValidErrorCode(): ErrorCode {
@@ -61,7 +62,7 @@ final class ConnectionResetException extends ConnectionException {
 }
 
 final class AlreadyExistsException extends Exception {
-  use _Private\ExceptionWithSingleErrorCodeTrait;
+  use _OS\ExceptionWithSingleErrorCodeTrait;
 
   <<__Override>>
   public static function _getValidErrorCode(): ErrorCode {
@@ -70,7 +71,7 @@ final class AlreadyExistsException extends Exception {
 }
 
 final class NotFoundException extends Exception {
-  use _Private\ExceptionWithSingleErrorCodeTrait;
+  use _OS\ExceptionWithSingleErrorCodeTrait;
 
   <<__Override>>
   public static function _getValidErrorCode(): ErrorCode {
@@ -79,7 +80,7 @@ final class NotFoundException extends Exception {
 }
 
 final class IsADirectoryException extends Exception {
-  use _Private\ExceptionWithSingleErrorCodeTrait;
+  use _OS\ExceptionWithSingleErrorCodeTrait;
 
   <<__Override>>
   public static function _getValidErrorCode(): ErrorCode {
@@ -88,7 +89,7 @@ final class IsADirectoryException extends Exception {
 }
 
 final class IsNotADirectoryException extends Exception {
-  use _Private\ExceptionWithSingleErrorCodeTrait;
+  use _OS\ExceptionWithSingleErrorCodeTrait;
 
   <<__Override>>
   public static function _getValidErrorCode(): ErrorCode {
@@ -97,7 +98,7 @@ final class IsNotADirectoryException extends Exception {
 }
 
 final class PermissionException extends Exception {
-  use _Private\ExceptionWithMultipleErrorCodesTrait;
+  use _OS\ExceptionWithMultipleErrorCodesTrait;
 
   <<__Override>>
   public static function _getValidErrorCodes(): keyset<ErrorCode> {
@@ -109,7 +110,7 @@ final class PermissionException extends Exception {
 }
 
 final class ProcessLookupException extends Exception {
-  use _Private\ExceptionWithSingleErrorCodeTrait;
+  use _OS\ExceptionWithSingleErrorCodeTrait;
 
   <<__Override>>
   public static function _getValidErrorCode(): ErrorCode {
@@ -118,7 +119,7 @@ final class ProcessLookupException extends Exception {
 }
 
 final class TimeoutError extends Exception {
-  use _Private\ExceptionWithSingleErrorCodeTrait;
+  use _OS\ExceptionWithSingleErrorCodeTrait;
 
   <<__Override>>
   public static function _getValidErrorCode(): ErrorCode {

--- a/src/tcp/CloseableSocket.php
+++ b/src/tcp/CloseableSocket.php
@@ -11,8 +11,9 @@
 namespace HH\Lib\Experimental\TCP;
 
 use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\_Private\_TCP;
 
-<<__Sealed(_Private\CloseableTCPSocket::class)>>
+<<__Sealed(_TCP\CloseableTCPSocket::class)>>
 interface CloseableSocket
   extends Socket, Network\CloseableSocket {
 }

--- a/src/tcp/DisposableSocket.php
+++ b/src/tcp/DisposableSocket.php
@@ -11,8 +11,9 @@
 namespace HH\Lib\Experimental\TCP;
 
 use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\_Private\_TCP;
 
-<<__Sealed(_Private\DisposableTCPSocket::class)>>
+<<__Sealed(_TCP\DisposableTCPSocket::class)>>
 interface DisposableSocket
   extends Socket, Network\DisposableSocket {
 }

--- a/src/tcp/Server.php
+++ b/src/tcp/Server.php
@@ -11,6 +11,7 @@
 namespace HH\Lib\Experimental\TCP;
 
 use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\_Private\{_Network, _TCP};
 
 final class Server
   implements Network\Server<Socket, DisposableSocket, CloseableSocket> {
@@ -36,7 +37,7 @@ final class Server
         break;
     }
 
-    return await Network\_Private\socket_create_bind_listen_async(
+    return await _Network\socket_create_bind_listen_async(
       $af,
       \SOCK_STREAM,
       \SOL_TCP,
@@ -49,18 +50,18 @@ final class Server
 
   <<__ReturnDisposable>>
   public async function nextConnectionAsync(): Awaitable<DisposableSocket> {
-    return new _Private\DisposableTCPSocket(
+    return new _TCP\DisposableTCPSocket(
       await $this->nextConnectionNDAsync(),
     );
   }
 
   public async function nextConnectionNDAsync(): Awaitable<CloseableSocket> {
-    return await Network\_Private\socket_accept_async($this->impl)
-      |> new _Private\CloseableTCPSocket($$);
+    return await _Network\socket_accept_async($this->impl)
+      |> new _TCP\CloseableTCPSocket($$);
   }
 
   public function getLocalAddress(): (string, int) {
-    return Network\_Private\get_sock_name($this->impl);
+    return _Network\get_sock_name($this->impl);
   }
 
   public function stopListening(): void {

--- a/src/tcp/_Private/CloseableTCPSocket.php
+++ b/src/tcp/_Private/CloseableTCPSocket.php
@@ -8,25 +8,26 @@
  *
  */
 
-namespace HH\Lib\Experimental\TCP\_Private;
+namespace HH\Lib\_Private\_TCP;
 
 use namespace HH\Lib\Experimental\{IO, Network, TCP};
+use namespace HH\Lib\_Private\{_IO, _Network};
 
 final class CloseableTCPSocket
-  extends IO\_Private\LegacyPHPResourceHandle
+  extends _IO\LegacyPHPResourceHandle
   implements TCP\CloseableSocket, IO\CloseableReadWriteHandle {
-  use IO\_Private\LegacyPHPResourceReadHandleTrait;
-  use IO\_Private\LegacyPHPResourceWriteHandleTrait;
+  use _IO\LegacyPHPResourceReadHandleTrait;
+  use _IO\LegacyPHPResourceWriteHandleTrait;
 
   public function __construct(resource $impl) {
     parent::__construct($impl);
   }
 
   public function getLocalAddress(): (string, int) {
-    return Network\_Private\get_sock_name($this->impl);
+    return _Network\get_sock_name($this->impl);
   }
 
   public function getPeerAddress(): (string, int) {
-    return Network\_Private\get_peer_name($this->impl);
+    return _Network\get_peer_name($this->impl);
   }
 }

--- a/src/tcp/_Private/DisposableTCPSocket.php
+++ b/src/tcp/_Private/DisposableTCPSocket.php
@@ -8,19 +8,20 @@
  *
  */
 
-namespace HH\Lib\Experimental\TCP\_Private;
+namespace HH\Lib\_Private\_TCP;
 
 use namespace HH\Lib\Experimental\{IO, TCP};
+use namespace HH\Lib\_Private\_IO;
 
 final class DisposableTCPSocket
-  extends IO\_Private\DisposableHandleWrapper<TCP\CloseableSocket>
+  extends _IO\DisposableHandleWrapper<TCP\CloseableSocket>
   implements
     \IAsyncDisposable,
     IO\DisposableReadWriteHandle,
     TCP\DisposableSocket {
 
-  use IO\_Private\DisposableReadHandleWrapperTrait<TCP\CloseableSocket>;
-  use IO\_Private\DisposableWriteHandleWrapperTrait<TCP\CloseableSocket>;
+  use _IO\DisposableReadHandleWrapperTrait<TCP\CloseableSocket>;
+  use _IO\DisposableWriteHandleWrapperTrait<TCP\CloseableSocket>;
 
   public function __construct(TCP\CloseableSocket $impl) {
     parent::__construct($impl);

--- a/src/tcp/connect.php
+++ b/src/tcp/connect.php
@@ -11,6 +11,7 @@
 namespace HH\Lib\Experimental\TCP;
 
 use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\_Private\{_Network, _TCP};
 
 /** Connect to a socket asynchronously, returning a non-disposable handle.
  *
@@ -59,14 +60,14 @@ async function connect_nd_async(
     $err = \socket_last_error();
     $err_message = "socket() failed";
     if ($sock is resource) {
-      $err = await Network\_Private\socket_connect_async($sock, $host, $port, $timeout);
+      $err = await _Network\socket_connect_async($sock, $host, $port, $timeout);
       if ($err === 0) {
-        return new namespace\_Private\CloseableTCPSocket($sock);
+        return new _TCP\CloseableTCPSocket($sock);
       }
       $err_message = 'connect() failed';
     }
   }
-  Network\_Private\throw_socket_error($err, $err_message);
+  _Network\throw_socket_error($err, $err_message);
 }
 
 /** Connect to a socket asynchronously, returning a disposable handle.
@@ -81,5 +82,5 @@ async function connect_async(
   ConnectOptions $opts = shape(),
 ): Awaitable<DisposableSocket> {
   $nd = await connect_nd_async($host, $port, $opts);
-  return new _Private\DisposableTCPSocket($nd);
+  return new _TCP\DisposableTCPSocket($nd);
 }

--- a/src/unix/CloseableSocket.php
+++ b/src/unix/CloseableSocket.php
@@ -11,7 +11,8 @@
 namespace HH\Lib\Experimental\Unix;
 
 use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\_Private\_Unix;
 
-<<__Sealed(_Private\CloseableSocket::class)>>
+<<__Sealed(_Unix\CloseableSocket::class)>>
 interface CloseableSocket extends Socket, Network\CloseableSocket {
 }

--- a/src/unix/DisposableSocket.php
+++ b/src/unix/DisposableSocket.php
@@ -11,7 +11,8 @@
 namespace HH\Lib\Experimental\Unix;
 
 use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\_Private\_Unix;
 
-<<__Sealed(_Private\DisposableSocket::class)>>
+<<__Sealed(_Unix\DisposableSocket::class)>>
 interface DisposableSocket extends Socket, Network\DisposableSocket {
 }

--- a/src/unix/Server.php
+++ b/src/unix/Server.php
@@ -11,6 +11,7 @@
 namespace HH\Lib\Experimental\Unix;
 
 use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\_Private\{_Network, _Unix};
 
 final class Server
   implements Network\Server<Socket, DisposableSocket, CloseableSocket> {
@@ -22,7 +23,7 @@ final class Server
 
   /** Create a bound and listening instance */
   public static async function createAsync(string $path): Awaitable<this> {
-    return await Network\_Private\socket_create_bind_listen_async(
+    return await _Network\socket_create_bind_listen_async(
       \AF_UNIX,
       \SOCK_STREAM,
       /* proto = */ 0,
@@ -34,16 +35,16 @@ final class Server
 
   <<__ReturnDisposable>>
   public async function nextConnectionAsync(): Awaitable<DisposableSocket> {
-    return new _Private\DisposableSocket(await $this->nextConnectionNDAsync());
+    return new _Unix\DisposableSocket(await $this->nextConnectionNDAsync());
   }
 
   public async function nextConnectionNDAsync(): Awaitable<CloseableSocket> {
-    return await Network\_Private\socket_accept_async($this->impl)
-      |> new _Private\CloseableSocket($$);
+    return await _Network\socket_accept_async($this->impl)
+      |> new _Unix\CloseableSocket($$);
   }
 
   public function getLocalAddress(): string {
-    return Network\_Private\get_sock_name($this->impl)[0];
+    return _Network\get_sock_name($this->impl)[0];
   }
 
   public function stopListening(): void {

--- a/src/unix/_Private/CloseableSocket.php
+++ b/src/unix/_Private/CloseableSocket.php
@@ -8,25 +8,26 @@
  *
  */
 
-namespace HH\Lib\Experimental\Unix\_Private;
+namespace HH\Lib\_Private\_Unix;
 
 use namespace HH\Lib\Experimental\{IO, Network, Unix};
+use namespace HH\Lib\_Private\{_IO, _Network};
 
 final class CloseableSocket
-  extends IO\_Private\LegacyPHPResourceHandle
+  extends _IO\LegacyPHPResourceHandle
   implements Unix\CloseableSocket, IO\CloseableReadWriteHandle {
-  use IO\_Private\LegacyPHPResourceReadHandleTrait;
-  use IO\_Private\LegacyPHPResourceWriteHandleTrait;
+  use _IO\LegacyPHPResourceReadHandleTrait;
+  use _IO\LegacyPHPResourceWriteHandleTrait;
 
   public function __construct(resource $impl) {
     parent::__construct($impl);
   }
 
   public function getLocalAddress(): string {
-    return Network\_Private\get_sock_name($this->impl)[0];
+    return _Network\get_sock_name($this->impl)[0];
   }
 
   public function getPeerAddress(): string {
-    return Network\_Private\get_peer_name($this->impl)[0];
+    return _Network\get_peer_name($this->impl)[0];
   }
 }

--- a/src/unix/_Private/DisposableSocket.php
+++ b/src/unix/_Private/DisposableSocket.php
@@ -8,21 +8,22 @@
  *
  */
 
-namespace HH\Lib\Experimental\Unix\_Private;
+namespace HH\Lib\_Private\_Unix;
 
 use namespace HH\Lib\Experimental\{IO, Unix};
+use namespace HH\Lib\_Private\_IO;
 
 final class DisposableSocket
-  extends IO\_Private\DisposableHandleWrapper<Unix\CloseableSocket>
+  extends _IO\DisposableHandleWrapper<Unix\CloseableSocket>
   implements
     \IAsyncDisposable,
     IO\DisposableReadWriteHandle,
     Unix\DisposableSocket {
 
-  use IO\_Private\DisposableReadHandleWrapperTrait<
+  use _IO\DisposableReadHandleWrapperTrait<
     Unix\CloseableSocket,
   >;
-  use IO\_Private\DisposableWriteHandleWrapperTrait<
+  use _IO\DisposableWriteHandleWrapperTrait<
     Unix\CloseableSocket,
   >;
 

--- a/src/unix/connect.php
+++ b/src/unix/connect.php
@@ -11,6 +11,7 @@
 namespace HH\Lib\Experimental\Unix;
 
 use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\_Private\{_Network, _Unix};
 
 /** Asynchronously connect to the specified unix socket, returning a
  * non-disposable handle.
@@ -27,21 +28,21 @@ async function connect_nd_async(
   /* HH_IGNORE_ERROR[2049] PHP STDLib */
   /* HH_IGNORE_ERROR[4107] PHP STDLib */
   if ($sock is resource) {
-    $err = await Network\_Private\socket_connect_async(
+    $err = await _Network\socket_connect_async(
       $sock,
       $path,
       0,
       $opts['timeout'] ?? null,
     );
     if ($err === 0) {
-      return new _Private\CloseableSocket($sock);
+      return new _Unix\CloseableSocket($sock);
     }
   } else {
     /* HH_IGNORE_ERROR[2049] PHP STDLib */
     /* HH_IGNORE_ERROR[4107] PHP STDLib */
     $err = \socket_last_error() as int;
   }
-  Network\_Private\throw_socket_error($err, 'connect() failed');
+  _Network\throw_socket_error($err, 'connect() failed');
 }
 
 /** Asynchronously connect to the specified unix socket, returning a disposable
@@ -52,5 +53,5 @@ async function connect_nd_async(
 <<__ReturnDisposable>>
 async function connect_async(string $path): Awaitable<DisposableSocket> {
   $nd = await connect_nd_async($path);
-  return new _Private\DisposableSocket($nd);
+  return new _Unix\DisposableSocket($nd);
 }

--- a/tests/os/HSLOSEnumSubsetsTest.php
+++ b/tests/os/HSLOSEnumSubsetsTest.php
@@ -11,6 +11,7 @@
 use namespace HH\Lib\Experimental\OS;
 
 use namespace HH\Lib\Keyset;
+use namespace HH\Lib\_Private\_OS;
 use function Facebook\FBExpect\expect; // @oss-enable
 use type Facebook\HackTest\HackTest; // @oss-enable
 use type Facebook\HackTest\DataProvider; // @oss-enable
@@ -19,35 +20,35 @@ use type Facebook\HackTest\DataProvider; // @oss-enable
 // @oss-disable: <<Oncalls('hf')>>
 final class HSLOSEnumSubsetsTest extends HackTest {
   public function testGAIErrorContainsAllPlatforms(): void {
-    $mac = OS\_Private\MacOS_GAIError::getNames();
-    $gnu = OS\_Private\GNU_GAIError::getNames();
+    $mac = _OS\MacOS_GAIError::getNames();
+    $gnu = _OS\GNU_GAIError::getNames();
 
     $combined = Keyset\sort(Keyset\flatten(vec[$mac, $gnu]));
 
-    expect($combined)->toEqual(Keyset\sort(OS\_Private\GAIError::getNames()));
+    expect($combined)->toEqual(Keyset\sort(_OS\GAIError::getNames()));
   }
 
   public function testEnumNamesEqualValues(): void {
     expect(keyset(OS\ErrorCode::getNames()))->toEqual(
       keyset(OS\ErrorCode::getValues()),
     );
-    expect(keyset(OS\_Private\GAIError::getNames()))->toEqual(
-      keyset(OS\_Private\GAIError::getValues()),
+    expect(keyset(_OS\GAIError::getNames()))->toEqual(
+      keyset(_OS\GAIError::getValues()),
     );
   }
 
   public function testErrorCodeContainsEverything(): void {
-    $gai = OS\_Private\GAIError::getNames();
+    $gai = _OS\GAIError::getNames();
 
-    $errno = OS\_Private\Errno::getNames();
+    $errno = _OS\Errno::getNames();
     $herror = Keyset\map(
-      OS\_Private\HError::getNames(),
+      _OS\HError::getNames(),
       $name ==> 'HERROR_'.$name,
     );
 
     // EAI_SYSTEM means that `errno` contains the cause, so
     // shouldn't be returned as an ErrorCode
-    unset($gai[OS\_Private\GAIError::EAI_SYSTEM]);
+    unset($gai[_OS\GAIError::EAI_SYSTEM]);
 
     expect(Keyset\sort(keyset(OS\ErrorCode::getNames())))->toEqual(
       Keyset\sort(Keyset\flatten(vec[$errno, $herror, $gai])),


### PR DESCRIPTION
Old: `HH\Lib\Experimental\Foo\_Private`
New: `HH\Lib\_Private\_Foo`

Reduces need for `as`, and if used consistently, increases readability -
for example, `IO` can reasonable need to refer to IO and OS, and their
private versions; if done consistently, this is `IO\foo`, `_IO\foo`,
`OS\foo` and `_OS\foo`, rather than pulling in multiple namespaces named
'_Private'