### PR TITLE
Remove "Experimental\\" from HSL IO, OS namespaces. No change to status.

### DIFF
--- a/src/debug/dump.php
+++ b/src/debug/dump.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\Experimental\Debug;
 
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 
 /** Return a human-readable string representation of a value */
 function dump_s(<<__AcceptDisposable>> mixed $value): string {

--- a/src/file/AlreadyLockedException.php
+++ b/src/file/AlreadyLockedException.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\File;
+namespace HH\Lib\File;
 
 /**
  * Indicates that a lock failed, because the file is already locked.

--- a/src/file/CloseableHandle.php
+++ b/src/file/CloseableHandle.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\File;
+namespace HH\Lib\File;
 
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 
 interface CloseableHandle extends IO\CloseableSeekableHandle, Handle {
 }

--- a/src/file/DisposableHandle.php
+++ b/src/file/DisposableHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\File;
+namespace HH\Lib\File;
 
 interface DisposableReadHandle extends \IAsyncDisposable, ReadHandle {
 }

--- a/src/file/Handle.php
+++ b/src/file/Handle.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\File;
+namespace HH\Lib\File;
 
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 
 interface Handle extends IO\SeekableHandle {
   /**

--- a/src/file/Lock.php
+++ b/src/file/Lock.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\File;
+namespace HH\Lib\File;
 
-use namespace HH\Lib\Experimental\{IO, OS};
+use namespace HH\Lib\{IO, OS};
 
 /**
  * A File Lock, which is unlocked as a disposable. To acquire one, call `lock`

--- a/src/file/LockType.php
+++ b/src/file/LockType.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\File;
+namespace HH\Lib\File;
 
 enum LockType: int as int {
   /**

--- a/src/file/Path.php
+++ b/src/file/Path.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\File;
+namespace HH\Lib\File;
 
 use namespace HH\Lib\{Str, Vec};
 

--- a/src/file/WriteMode.php
+++ b/src/file/WriteMode.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\File;
+namespace HH\Lib\File;
 
 enum WriteMode: string {
   /**

--- a/src/file/_Private/CloseableFileHandle.php
+++ b/src/file/_Private/CloseableFileHandle.php
@@ -12,7 +12,7 @@ namespace HH\Lib\_Private\_File;
 
 use namespace HH\Lib\Str;
 use namespace HH\Lib\_Private\{_IO, _OS};
-use namespace HH\Lib\Experimental\{IO, File, OS};
+use namespace HH\Lib\{IO, File, OS};
 use type HH\Lib\_Private\PHPWarningSuppressor;
 
 <<__ConsistentConstruct>>

--- a/src/file/_Private/CloseableReadHandle.php
+++ b/src/file/_Private/CloseableReadHandle.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_File;
 
-use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\{File, IO};
 use namespace HH\Lib\_Private\_IO;
 
 final class CloseableReadHandle

--- a/src/file/_Private/CloseableReadWriteHandle.php
+++ b/src/file/_Private/CloseableReadWriteHandle.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_File;
 
-use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\{File, IO};
 use namespace HH\Lib\_Private\_IO;
 
 final class CloseableReadWriteHandle

--- a/src/file/_Private/CloseableWriteHandle.php
+++ b/src/file/_Private/CloseableWriteHandle.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_File;
 
-use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\{File, IO};
 use namespace HH\Lib\_Private\_IO;
 
 final class CloseableWriteHandle

--- a/src/file/_Private/DisposableFileHandle.php
+++ b/src/file/_Private/DisposableFileHandle.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_File;
 
-use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\{File, IO};
 use namespace HH\Lib\_Private\_IO;
 
 <<__ConsistentConstruct>>

--- a/src/file/_Private/DisposableFileReadHandle.php
+++ b/src/file/_Private/DisposableFileReadHandle.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_File;
 
-use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\{File, IO};
 use namespace HH\Lib\_Private\_IO;
 
 final class DisposableFileReadHandle

--- a/src/file/_Private/DisposableFileReadWriteHandle.php
+++ b/src/file/_Private/DisposableFileReadWriteHandle.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_File;
 
-use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\{File, IO};
 use namespace HH\Lib\_Private\_IO;
 
 final class DisposableFileReadWriteHandle

--- a/src/file/_Private/DisposableFileWriteHandle.php
+++ b/src/file/_Private/DisposableFileWriteHandle.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_File;
 
-use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\{File, IO};
 use namespace HH\Lib\_Private\_IO;
 
 final class DisposableFileWriteHandle

--- a/src/file/_Private/TemporaryFile.php
+++ b/src/file/_Private/TemporaryFile.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_File;
 
-use namespace HH\Lib\Experimental\{File, IO};
+use namespace HH\Lib\{File, IO};
 use namespace HH\Lib\_Private\_IO;
 
 final class TemporaryFile

--- a/src/file/open.php
+++ b/src/file/open.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\File;
+namespace HH\Lib\File;
 use namespace HH\Lib\_Private\_File;
 
 function open_read_only_nd(string $path): CloseableReadHandle {

--- a/src/file/temporary_file.php
+++ b/src/file/temporary_file.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\File;
+namespace HH\Lib\File;
 use namespace HH\Lib\_Private\_File;
 
 <<__ReturnDisposable>>

--- a/src/io/CloseableHandle.php
+++ b/src/io/CloseableHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 /**
  * A non-disposable handle that is explicitly closeable.

--- a/src/io/CloseableReadHandle.php
+++ b/src/io/CloseableReadHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 interface CloseableReadHandle extends ReadHandle, CloseableHandle {
 }

--- a/src/io/CloseableReadWriteHandle.php
+++ b/src/io/CloseableReadWriteHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 interface CloseableReadWriteHandle
   extends ReadWriteHandle, CloseableReadHandle, CloseableWriteHandle {

--- a/src/io/CloseableSeekableHandle.php
+++ b/src/io/CloseableSeekableHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 interface CloseableSeekableHandle extends SeekableHandle, CloseableHandle {
 }

--- a/src/io/CloseableSeekableReadHandle.php
+++ b/src/io/CloseableSeekableReadHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 interface CloseableSeekableReadHandle extends
   SeekableReadHandle,

--- a/src/io/CloseableSeekableReadWriteHandle.php
+++ b/src/io/CloseableSeekableReadWriteHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 interface CloseableSeekableReadWriteHandle
   extends

--- a/src/io/CloseableSeekableWriteHandle.php
+++ b/src/io/CloseableSeekableWriteHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 interface CloseableSeekableWriteHandle extends
   SeekableWriteHandle,

--- a/src/io/CloseableWriteHandle.php
+++ b/src/io/CloseableWriteHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 interface CloseableWriteHandle extends WriteHandle, CloseableHandle {
 }

--- a/src/io/DiposableReadWriteHandle.php
+++ b/src/io/DiposableReadWriteHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 interface DisposableReadWriteHandle
   extends ReadWriteHandle, DisposableReadHandle, DisposableWriteHandle {

--- a/src/io/DisposableReadHandle.php
+++ b/src/io/DisposableReadHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 interface DisposableReadHandle extends ReadHandle, \IAsyncDisposable {
 }

--- a/src/io/DisposableSeekableHandle.php
+++ b/src/io/DisposableSeekableHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 interface DisposableSeekableHandle
   extends SeekableHandle, \IAsyncDisposable {

--- a/src/io/DisposableSeekableReadHandle.php
+++ b/src/io/DisposableSeekableReadHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 interface DisposableSeekableReadHandle
   extends DisposableSeekableHandle, SeekableReadHandle, DisposableReadHandle {

--- a/src/io/DisposableSeekableReadWriteHandle.php
+++ b/src/io/DisposableSeekableReadWriteHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 interface DisposableSeekableReadWriteHandle
   extends

--- a/src/io/DisposableSeekableWriteHandle.php
+++ b/src/io/DisposableSeekableWriteHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 interface DisposableSeekableWriteHandle
   extends DisposableSeekableHandle, SeekableWriteHandle, DisposableWriteHandle {

--- a/src/io/DisposableWriteHandle.php
+++ b/src/io/DisposableWriteHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 interface DisposableWriteHandle extends WriteHandle, \IAsyncDisposable {
 }

--- a/src/io/Handle.php
+++ b/src/io/Handle.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
-use namespace HH\Lib\Experimental\{File, Network};
+use namespace HH\Lib\{File, Network};
 
 /** An interface for an IO stream.
  *

--- a/src/io/ReadHandle.php
+++ b/src/io/ReadHandle.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
-use namespace HH\Lib\Experimental\Fileystem;
+use namespace HH\Lib\Fileystem;
 use namespace HH\Lib\_Private;
 
 /** An `IO\Handle` that is readable. */

--- a/src/io/ReadWriteHandle.php
+++ b/src/io/ReadWriteHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 /**
  * An interface for read and write handles.

--- a/src/io/SeekableHandle.php
+++ b/src/io/SeekableHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 /** A handle that can have its' position changed. */
 interface SeekableHandle extends Handle {

--- a/src/io/SeekableReadHandle.php
+++ b/src/io/SeekableReadHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 interface SeekableReadHandle extends ReadHandle, SeekableHandle {
 }

--- a/src/io/SeekableReadWriteHandle.php
+++ b/src/io/SeekableReadWriteHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 /**
  * An interface for seekable read and write handles.

--- a/src/io/SeekableWriteHandle.php
+++ b/src/io/SeekableWriteHandle.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 interface SeekableWriteHandle extends SeekableHandle, WriteHandle {
 }

--- a/src/io/UserspaceHandle.php
+++ b/src/io/UserspaceHandle.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 // @deprecated UserspaceHandle has been deprecated, use
-// HH\Lib\Experimental\IO\Handle instead.
+// HH\Lib\IO\Handle instead.
 interface UserspaceHandle extends Handle {
 }

--- a/src/io/WriteHandle.php
+++ b/src/io/WriteHandle.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
-use namespace HH\Lib\Experimental\Fileystem;
+use namespace HH\Lib\Fileystem;
 use namespace HH\Lib\_Private;
 
 /** An interface for a writable Handle.

--- a/src/io/_Private/DisposableHandleWrapper.php
+++ b/src/io/_Private/DisposableHandleWrapper.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\{Experimental\Fileystem, Experimental\IO, Str};
+use namespace HH\Lib\{Fileystem, IO, Str};
 
 abstract class DisposableHandleWrapper<T as IO\CloseableHandle>
   implements IO\Handle, \IAsyncDisposable {

--- a/src/io/_Private/DisposableReadHandleWrapperTrait.php
+++ b/src/io/_Private/DisposableReadHandleWrapperTrait.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\{Experimental\Fileystem, Experimental\IO, Str};
+use namespace HH\Lib\{Fileystem, IO, Str};
 
 trait DisposableReadHandleWrapperTrait<T as IO\CloseableReadHandle>
   implements IO\DisposableReadHandle {

--- a/src/io/_Private/DisposableSeekableHandleWrapperTrait.php
+++ b/src/io/_Private/DisposableSeekableHandleWrapperTrait.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 
 trait DisposableSeekableHandleWrapperTrait<T as IO\CloseableSeekableHandle>
   implements IO\DisposableSeekableHandle {

--- a/src/io/_Private/DisposableWriteHandleWrapperTrait.php
+++ b/src/io/_Private/DisposableWriteHandleWrapperTrait.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\{Experimental\Fileystem, Experimental\IO, Str};
+use namespace HH\Lib\{Fileystem, IO, Str};
 
 trait DisposableWriteHandleWrapperTrait<T as IO\CloseableWriteHandle>
   implements IO\DisposableWriteHandle {

--- a/src/io/_Private/LegacyPHPResourceHandle.php
+++ b/src/io/_Private/LegacyPHPResourceHandle.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\{Experimental\IO, Str};
+use namespace HH\Lib\{IO, Str};
 use type HH\Lib\_Private\PHPWarningSuppressor;
 
 abstract class LegacyPHPResourceHandle implements IO\CloseableHandle {

--- a/src/io/_Private/LegacyPHPResourceReadHandleTrait.php
+++ b/src/io/_Private/LegacyPHPResourceReadHandleTrait.php
@@ -11,7 +11,7 @@
 namespace HH\Lib\_Private\_IO;
 
 use namespace HH\Lib\Str;
-use namespace HH\Lib\Experimental\{IO, OS};
+use namespace HH\Lib\{IO, OS};
 use namespace HH\Lib\_Private\_OS;
 use type HH\Lib\_Private\PHPWarningSuppressor;
 

--- a/src/io/_Private/LegacyPHPResourceSeekableHandleTrait.php
+++ b/src/io/_Private/LegacyPHPResourceSeekableHandleTrait.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\{Experimental\IO, Str};
+use namespace HH\Lib\{IO, Str};
 use type HH\Lib\_Private\PHPWarningSuppressor;
 
 trait LegacyPHPResourceSeekableHandleTrait implements IO\SeekableHandle {

--- a/src/io/_Private/LegacyPHPResourceWriteHandleTrait.php
+++ b/src/io/_Private/LegacyPHPResourceWriteHandleTrait.php
@@ -12,7 +12,7 @@ namespace HH\Lib\_Private\_IO;
 
 use namespace HH\Lib\Str;
 use namespace HH\Lib\_Private\_OS;
-use namespace HH\Lib\Experimental\{IO, OS};
+use namespace HH\Lib\{IO, OS};
 use type HH\Lib\_Private\PHPWarningSuppressor;
 
 trait LegacyPHPResourceWriteHandleTrait implements IO\WriteHandle {

--- a/src/io/_Private/PipeReadHandle.php
+++ b/src/io/_Private/PipeReadHandle.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 
 final class PipeReadHandle
   extends LegacyPHPResourceHandle

--- a/src/io/_Private/PipeWriteHandle.php
+++ b/src/io/_Private/PipeWriteHandle.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 
 final class PipeWriteHandle
   extends LegacyPHPResourceHandle

--- a/src/io/_Private/StdioReadHandle.php
+++ b/src/io/_Private/StdioReadHandle.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 
 final class StdioReadHandle
   extends LegacyPHPResourceHandle

--- a/src/io/_Private/StdioWriteHandle.php
+++ b/src/io/_Private/StdioWriteHandle.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 
 final class StdioWriteHandle
   extends LegacyPHPResourceHandle

--- a/src/io/pipe.php
+++ b/src/io/pipe.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
 use namespace HH\Lib\_Private\_IO;
 

--- a/src/io/stdio.php
+++ b/src/io/stdio.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\IO;
+namespace HH\Lib\IO;
 
-use namespace HH\Lib\Experimental\OS;
+use namespace HH\Lib\OS;
 use namespace HH\Lib\_Private\{_IO, _OS};
 
 /** Return STDOUT for the server process.

--- a/src/network/CloseableSocket.php
+++ b/src/network/CloseableSocket.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\Network;
+namespace HH\Lib\Network;
 
-use namespace HH\Lib\Experimental\{IO, TCP, Unix};
+use namespace HH\Lib\{IO, TCP, Unix};
 
 <<
   __Sealed(

--- a/src/network/DisposableSocket.php
+++ b/src/network/DisposableSocket.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\Network;
+namespace HH\Lib\Network;
 
-use namespace HH\Lib\Experimental\{IO, TCP, Unix};
+use namespace HH\Lib\{IO, TCP, Unix};
 
 <<__Sealed(TCP\DisposableSocket::class, Unix\DisposableSocket::class)>>
 interface DisposableSocket extends Socket, IO\DisposableReadWriteHandle {

--- a/src/network/IPProtocolBehavior.php
+++ b/src/network/IPProtocolBehavior.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\Network;
+namespace HH\Lib\Network;
 
 /** General behavior for selecting which IP version to use.
  *

--- a/src/network/IPProtocolVersion.php
+++ b/src/network/IPProtocolVersion.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\Network;
+namespace HH\Lib\Network;
 
 /** A specific version of IP.
  *

--- a/src/network/Server.php
+++ b/src/network/Server.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\Network;
+namespace HH\Lib\Network;
 
 /** Generic interface for a class able to accept socket connections.
  *

--- a/src/network/Socket.php
+++ b/src/network/Socket.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\Network;
+namespace HH\Lib\Network;
 
-use namespace HH\Lib\Experimental\{IO, TCP, Unix};
+use namespace HH\Lib\{IO, TCP, Unix};
 
 /** A handle representing a connection between processes.
  *

--- a/src/network/SocketOptions.php
+++ b/src/network/SocketOptions.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\Network;
+namespace HH\Lib\Network;
 
 type SocketOptions = shape(
   ?'SO_REUSEADDR' => bool,

--- a/src/network/_Private/set_socket_options.php
+++ b/src/network/_Private/set_socket_options.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_Network;
 
-use type HH\Lib\Experimental\Network\SocketOptions;
+use type HH\Lib\Network\SocketOptions;
 
 function set_socket_options(resource $sock, SocketOptions $opts): void {
   if ($opts['SO_REUSEADDR'] ?? false) {

--- a/src/network/_Private/socket_create_bind_listen_async.php
+++ b/src/network/_Private/socket_create_bind_listen_async.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_Network;
 
-use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\Network;
 use namespace HH\Lib\_Private\_OS;
 use type HH\Lib\_Private\PHPWarningSuppressor;
 

--- a/src/network/_Private/throw_socket_error.php
+++ b/src/network/_Private/throw_socket_error.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_Network;
 
-use namespace HH\Lib\Experimental\{IO, Network, OS};
+use namespace HH\Lib\{IO, Network, OS};
 use namespace HH\Lib\_Private\_OS;
 use namespace HH\Lib\Str;
 

--- a/src/os/ErrorCode.php
+++ b/src/os/ErrorCode.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\OS;
+namespace HH\Lib\OS;
 
 /** OS-level error codes.
  *

--- a/src/os/Exception.php
+++ b/src/os/Exception.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\OS;
+namespace HH\Lib\OS;
 
 /**
  * Base class for exceptions reported by primitive native operations.

--- a/src/os/_Private.php
+++ b/src/os/_Private.php
@@ -10,6 +10,6 @@
 
 namespace HH\Lib\_Private\_OS;
 
-use namespace HH\Lib\Experimental\OS;
+use namespace HH\Lib\OS;
 
 const bool IS_MACOS = \PHP_OS === 'Darwin';

--- a/src/os/_Private/Errno.php
+++ b/src/os/_Private/Errno.php
@@ -11,7 +11,7 @@
 namespace HH\Lib\_Private\_OS;
 
 use namespace HH\Lib\{C, Str};
-use namespace HH\Lib\Experimental\OS;
+use namespace HH\Lib\OS;
 
 // hackfmt-ignore
 /** OS-level error number constants from `errno.h`.

--- a/src/os/_Private/HError.php
+++ b/src/os/_Private/HError.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_OS;
 
-use namespace HH\Lib\Experimental\OS;
+use namespace HH\Lib\OS;
 
 // hackfmt-ignore
 /** OS-level host error number constants from `netdb.h`.

--- a/src/os/_Private/exceptions.php
+++ b/src/os/_Private/exceptions.php
@@ -11,7 +11,7 @@
 namespace HH\Lib\_Private\_OS;
 
 use namespace HH\Lib\C;
-use namespace HH\Lib\Experimental\OS;
+use namespace HH\Lib\OS;
 
 trait ExceptionWithMultipleErrorCodesTrait {
   require extends OS\Exception;

--- a/src/os/exceptions.php
+++ b/src/os/exceptions.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\OS;
+namespace HH\Lib\OS;
 
 use namespace HH\Lib\C;
 use namespace HH\Lib\_Private\_OS;

--- a/src/tcp/CloseableSocket.php
+++ b/src/tcp/CloseableSocket.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\TCP;
+namespace HH\Lib\TCP;
 
-use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\Network;
 use namespace HH\Lib\_Private\_TCP;
 
 <<__Sealed(_TCP\CloseableTCPSocket::class)>>

--- a/src/tcp/ConnectOptions.php
+++ b/src/tcp/ConnectOptions.php
@@ -8,8 +8,8 @@
  *
  */
 
-namespace HH\Lib\Experimental\TCP;
-use namespace HH\Lib\Experimental\Network;
+namespace HH\Lib\TCP;
+use namespace HH\Lib\Network;
 
 type ConnectOptions = shape(
   ?'timeout' => ?float,

--- a/src/tcp/DisposableSocket.php
+++ b/src/tcp/DisposableSocket.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\TCP;
+namespace HH\Lib\TCP;
 
-use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\Network;
 use namespace HH\Lib\_Private\_TCP;
 
 <<__Sealed(_TCP\DisposableTCPSocket::class)>>

--- a/src/tcp/Server.php
+++ b/src/tcp/Server.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\TCP;
+namespace HH\Lib\TCP;
 
-use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\Network;
 use namespace HH\Lib\_Private\{_Network, _TCP};
 
 final class Server

--- a/src/tcp/ServerOptions.php
+++ b/src/tcp/ServerOptions.php
@@ -8,8 +8,8 @@
  *
  */
 
-namespace HH\Lib\Experimental\TCP;
-use namespace HH\Lib\Experimental\Network;
+namespace HH\Lib\TCP;
+use namespace HH\Lib\Network;
 
 type ServerOptions = shape(
   ?'socket_options' => Network\SocketOptions,

--- a/src/tcp/Socket.php
+++ b/src/tcp/Socket.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\TCP;
+namespace HH\Lib\TCP;
 
-use namespace HH\Lib\Experimental\{IO, Network};
+use namespace HH\Lib\{IO, Network};
 
 /**
  * A TCP client or server socket.

--- a/src/tcp/_Private/CloseableTCPSocket.php
+++ b/src/tcp/_Private/CloseableTCPSocket.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_TCP;
 
-use namespace HH\Lib\Experimental\{IO, Network, TCP};
+use namespace HH\Lib\{IO, Network, TCP};
 use namespace HH\Lib\_Private\{_IO, _Network};
 
 final class CloseableTCPSocket

--- a/src/tcp/_Private/DisposableTCPSocket.php
+++ b/src/tcp/_Private/DisposableTCPSocket.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_TCP;
 
-use namespace HH\Lib\Experimental\{IO, TCP};
+use namespace HH\Lib\{IO, TCP};
 use namespace HH\Lib\_Private\_IO;
 
 final class DisposableTCPSocket

--- a/src/tcp/connect.php
+++ b/src/tcp/connect.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\TCP;
+namespace HH\Lib\TCP;
 
-use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\Network;
 use namespace HH\Lib\_Private\{_Network, _TCP};
 
 /** Connect to a socket asynchronously, returning a non-disposable handle.

--- a/src/unix/CloseableSocket.php
+++ b/src/unix/CloseableSocket.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\Unix;
+namespace HH\Lib\Unix;
 
-use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\Network;
 use namespace HH\Lib\_Private\_Unix;
 
 <<__Sealed(_Unix\CloseableSocket::class)>>

--- a/src/unix/ConnectOptions.php
+++ b/src/unix/ConnectOptions.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\Experimental\Unix;
+namespace HH\Lib\Unix;
 
 type ConnectOptions = shape(
   ?'timeout' => ?float,

--- a/src/unix/DisposableSocket.php
+++ b/src/unix/DisposableSocket.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\Unix;
+namespace HH\Lib\Unix;
 
-use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\Network;
 use namespace HH\Lib\_Private\_Unix;
 
 <<__Sealed(_Unix\DisposableSocket::class)>>

--- a/src/unix/Server.php
+++ b/src/unix/Server.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\Unix;
+namespace HH\Lib\Unix;
 
-use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\Network;
 use namespace HH\Lib\_Private\{_Network, _Unix};
 
 final class Server

--- a/src/unix/Socket.php
+++ b/src/unix/Socket.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\Unix;
+namespace HH\Lib\Unix;
 
-use namespace HH\Lib\Experimental\{IO, Network};
+use namespace HH\Lib\{IO, Network};
 
 /** A Unix socket for a server or client connection.
  *

--- a/src/unix/_Private/CloseableSocket.php
+++ b/src/unix/_Private/CloseableSocket.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_Unix;
 
-use namespace HH\Lib\Experimental\{IO, Network, Unix};
+use namespace HH\Lib\{IO, Network, Unix};
 use namespace HH\Lib\_Private\{_IO, _Network};
 
 final class CloseableSocket

--- a/src/unix/_Private/DisposableSocket.php
+++ b/src/unix/_Private/DisposableSocket.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_Unix;
 
-use namespace HH\Lib\Experimental\{IO, Unix};
+use namespace HH\Lib\{IO, Unix};
 use namespace HH\Lib\_Private\_IO;
 
 final class DisposableSocket

--- a/src/unix/connect.php
+++ b/src/unix/connect.php
@@ -8,9 +8,9 @@
  *
  */
 
-namespace HH\Lib\Experimental\Unix;
+namespace HH\Lib\Unix;
 
-use namespace HH\Lib\Experimental\Network;
+use namespace HH\Lib\Network;
 use namespace HH\Lib\_Private\{_Network, _Unix};
 
 /** Asynchronously connect to the specified unix socket, returning a

--- a/tests/file/FileTest.php
+++ b/tests/file/FileTest.php
@@ -9,7 +9,7 @@
  */
 
 use namespace HH\Lib\Str;
-use namespace HH\Lib\Experimental\{File, OS};
+use namespace HH\Lib\{File, OS};
 
 use function Facebook\FBExpect\expect; // @oss-enable
 use type Facebook\HackTest\HackTest; // @oss-enable

--- a/tests/file/PathTest.php
+++ b/tests/file/PathTest.php
@@ -9,7 +9,7 @@
  */
 
 
-use namespace HH\Lib\Experimental\File;
+use namespace HH\Lib\File;
 
 use function Facebook\FBExpect\expect; // @oss-enable
 use type Facebook\HackTest\HackTest; // @oss-enable

--- a/tests/io/PipeTest.php
+++ b/tests/io/PipeTest.php
@@ -8,7 +8,7 @@
  *
  */
 
-use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\IO;
 
 use function Facebook\FBExpect\expect; // @oss-enable
 use type Facebook\HackTest\HackTest; // @oss-enable

--- a/tests/os/HSLOSEnumSubsetsTest.php
+++ b/tests/os/HSLOSEnumSubsetsTest.php
@@ -8,7 +8,7 @@
  *
  */
 
-use namespace HH\Lib\Experimental\OS;
+use namespace HH\Lib\OS;
 
 use namespace HH\Lib\Keyset;
 use namespace HH\Lib\_Private\_OS;

--- a/tests/tcp/HSLTCPTest.php
+++ b/tests/tcp/HSLTCPTest.php
@@ -9,13 +9,13 @@
  */
 
 use namespace HH\Lib\Vec;
-use namespace HH\Lib\Experimental\{IO, Network, OS, TCP};
+use namespace HH\Lib\{IO, Network, OS, TCP};
 
 use function Facebook\FBExpect\expect; // @oss-enable
 use type Facebook\HackTest\HackTest; // @oss-enable
 use type Facebook\HackTest\DataProvider; // @oss-enable
 // @oss-disable: use type HackTest;
-use type HH\Lib\Experimental\Network\{IPProtocolBehavior, IPProtocolVersion};
+use type HH\Lib\Network\{IPProtocolBehavior, IPProtocolVersion};
 use type HH\Lib\Ref;
 
 // @oss-disable: <<Oncalls('hf')>>

--- a/tests/unix/HSLUnixSocketTest.php
+++ b/tests/unix/HSLUnixSocketTest.php
@@ -8,14 +8,14 @@
  *
  */
 
-use namespace HH\Lib\Experimental\{Network, Unix};
+use namespace HH\Lib\{Network, Unix};
 use namespace HH\Lib\{Math, PseudoRandom};
 
 use function Facebook\FBExpect\expect; // @oss-enable
 use type Facebook\HackTest\HackTest; // @oss-enable
 use type Facebook\HackTest\DataProvider; // @oss-enable
 // @oss-disable: use type HackTest;
-use type HH\Lib\Experimental\Network\{IPProtocolBehavior, IPProtocolVersion};
+use type HH\Lib\Network\{IPProtocolBehavior, IPProtocolVersion};
 use type \HH\Lib\Ref;
 
 // @oss-disable: <<Oncalls('hf')>>


### PR DESCRIPTION
These libraries are still experimental - this remains indicated by the
package name, or by the internal path and lack of aliasing in flib.

Renaming as:
- the namespace indication is not necessary
- it makes moving things out of experimental a breaking change
- it's very awkward for namespaces that contain builtins and
non-builtings, e.g. `OS\`

Only doing this for IO/OS stuff for now as these are the only ones that
have builtins, and are under active development.