### PR TITLE
[easy] make HSL IO write API consistent with read API

### DIFF
--- a/src/io/WriteHandle.php
+++ b/src/io/WriteHandle.php
@@ -19,17 +19,32 @@ use namespace HH\Lib\_Private;
  * `rawWriteBlocking()` will immediately try to write to the handle.
  */
 interface WriteHandle extends Handle {
-
-  /** Possibly write some of the string.
+  /** An immediate unordered write.
+   *
+   * @see `genWrite()`
+   * @throws `OS\BlockingIOException` if the handle is a socket or similar,
+   *   and the write would block.
+   * @returns the number of bytes written on success
    *
    * Returns the number of bytes written, which may be 0.
    */
-  public function rawWriteBlocking(string $bytes): int;
+  public function write(string $bytes): int;
 
+  /** Write data, waiting if necessary.
+   *
+   * A wrapper around `write()` that will wait if `write()` would throw
+   * an `OS\BlockingIOException`
+   *
+   * It is possible for the write to succeed - check the return value and call
+   * again in  this case.
+   *
+   * @returns the number of bytes written, which may be less than the length of
+   *   input string.
+   */
   public function writeAsync(
     string $bytes,
-    ?float $timeout_seconds = null,
-  ): Awaitable<void>;
+    ?int $timeout_ns = null,
+  ): Awaitable<int>;
 
   public function flushAsync(): Awaitable<void>;
 }

--- a/src/io/WriteHandle.php
+++ b/src/io/WriteHandle.php
@@ -35,8 +35,8 @@ interface WriteHandle extends Handle {
    * A wrapper around `write()` that will wait if `write()` would throw
    * an `OS\BlockingIOException`
    *
-   * It is possible for the write to succeed - check the return value and call
-   * again in  this case.
+   * It is possible for the write to *partially* succeed - check the return
+   * value and call again if needed.
    *
    * @returns the number of bytes written, which may be less than the length of
    *   input string.

--- a/src/io/_Private/DisposableWriteHandleWrapperTrait.php
+++ b/src/io/_Private/DisposableWriteHandleWrapperTrait.php
@@ -17,15 +17,15 @@ trait DisposableWriteHandleWrapperTrait<T as IO\CloseableWriteHandle>
   require extends DisposableHandleWrapper<T>;
   require implements \IAsyncDisposable;
 
-  final public function rawWriteBlocking(string $bytes): int {
-    return $this->impl->rawWriteBlocking($bytes);
+  final public function write(string $bytes): int {
+    return $this->impl->write($bytes);
   }
 
   final public async function writeAsync(
     string $bytes,
-    ?float $timeout_seconds = null,
-  ): Awaitable<void> {
-    await $this->impl->writeAsync($bytes, $timeout_seconds);
+    ?int $timeout_ns = null,
+  ): Awaitable<int> {
+    return await $this->impl->writeAsync($bytes, $timeout_ns);
   }
 
   final public async function flushAsync(): Awaitable<void> {

--- a/src/io/_Private/FileDescriptorReadHandleTrait.php
+++ b/src/io/_Private/FileDescriptorReadHandleTrait.php
@@ -40,8 +40,7 @@ trait FileDescriptorReadHandleTrait implements IO\ReadHandle {
     $timeout_ns ??= 0;
 
     try {
-      $chunk = $this->read($max_bytes);
-      return $chunk;
+      return $this->read($max_bytes);
     } catch (OS\BlockingIOException $_) {
       // this means we need to wait for data, which we do below...
     }

--- a/src/io/_Private/LegacyPHPResourceReadHandleTrait.php
+++ b/src/io/_Private/LegacyPHPResourceReadHandleTrait.php
@@ -59,7 +59,6 @@ trait LegacyPHPResourceReadHandleTrait implements IO\ReadHandle {
     }
     $timeout_secs = $timeout_ns * 1.0E-9;
     await $this->selectAsync(\STREAM_AWAIT_READ, $timeout_secs);
-    $chunk = $this->read($max_bytes);
-    return $chunk;
+    return $this->read($max_bytes);
   }
 }


### PR DESCRIPTION
- `rawFooBlocking()` -> `foo()`, matching the `OS\` function
- `float $timeout_sec() = 0` -> `?int $timeout_ns = null`
- only do one `write()`; don't loop until the very end
  - this is less clearly the correct thing to do compared to `read()`,
    however given it's needed for `read()`, I think it's best for
    consistency
- clean up some `$chunk = foo(); return $chunk;` I saw while looking
  through the read implementations