### PR TITLE
Remove IO\server_output(), IO\server_error()

### DIFF
--- a/src/io/stdio.php
+++ b/src/io/stdio.php
@@ -13,26 +13,6 @@ namespace HH\Lib\IO;
 use namespace HH\Lib\OS;
 use namespace HH\Lib\_Private\{_IO, _OS};
 
-/** Return STDOUT for the server process.
- *
- * This is usually not the same thing as request output.
- *
- * @see request_output
- */
-<<__Memoize>>
-function server_output(): WriteHandle {
-  return new _IO\StdioWriteHandle('php://stdout');
-}
-
-/** Return STDERR for the server process.
- *
- * @see request_error
- */
-<<__Memoize>>
-function server_error(): WriteHandle {
-  return new _IO\StdioWriteHandle('php://stderr');
-}
-
 /** Return the output handle for the current request.
  *
  * This should generally be used for sending data to clients. In CLI mode, this
@@ -47,7 +27,7 @@ function request_output(): CloseableWriteHandle {
   /* HH_IGNORE_ERROR[2049] __PHPStdLib */
   /* HH_IGNORE_ERROR[4107] __PHPStdLib */
   if (\php_sapi_name() === "cli") {
-    return server_output() as CloseableWriteHandle;
+    return new _IO\StdioWriteHandle('php://stdout');
   }
   return new _IO\StdioWriteHandle('php://output');
 }
@@ -84,11 +64,11 @@ function request_errorx(): CloseableWriteHandle {
   /* HH_IGNORE_ERROR[4107] __PHPStdLib */
   if (\php_sapi_name() !== "cli") {
     _OS\throw_errno(
-      OS\Errno::ENOENT,
+      OS\Errno::EBADF,
       "There is no request_error() handle",
     );
   }
-  return server_error() as CloseableWriteHandle;
+  return new _IO\StdioWriteHandle('php://stderr');
 }
 
 /** Return the input handle for the current request.


### PR DESCRIPTION
I believe these are dangerous, and not actually useful; error logging
builtins should be used instead.

Dangerous as:
- it breaks fastcgi over STDIO
- it breaks anything else consuming HHVM output, perhaps e.g. log
  parsers
- if error logs are redirected with HHVM config option rather FD
  redirection, anything written to server_error() will not be in the
  error log
- exposing non-read-only per-process things to requests just seems like a
  bad idea. Makes more sense in PHP where there is a process-per-request
  (fastcgi is handled by a separate master process).