### PR TITLE
Remove `IO\WriteHandle::flushAsync()`

### DIFF
--- a/src/io/WriteHandle.php
+++ b/src/io/WriteHandle.php
@@ -46,8 +46,6 @@ interface WriteHandle extends Handle {
     ?int $timeout_ns = null,
   ): Awaitable<int>;
 
-  public function flushAsync(): Awaitable<void>;
-
   /** Write all of the requested data.
    *
    * A wrapper aroudn `writeAsync()` that will:

--- a/src/io/_Private/DisposableWriteHandleWrapperTrait.php
+++ b/src/io/_Private/DisposableWriteHandleWrapperTrait.php
@@ -28,10 +28,6 @@ trait DisposableWriteHandleWrapperTrait<T as IO\CloseableWriteHandle>
     return await $this->impl->writeAsync($bytes, $timeout_ns);
   }
 
-  final public async function flushAsync(): Awaitable<void> {
-    await $this->impl->flushAsync();
-  }
-
   final public async function writeAllAsync(
     string $bytes,
     ?int $timeout_ns = null,

--- a/src/io/_Private/FileDescriptorHandle.php
+++ b/src/io/_Private/FileDescriptorHandle.php
@@ -60,9 +60,6 @@ abstract class FileDescriptorHandle implements IO\CloseableHandle {
   }
 
   final public async function closeAsync(): Awaitable<void> {
-    if ($this is IO\WriteHandle) {
-      await $this->flushAsync();
-    }
     OS\close($this->impl);
   }
 }

--- a/src/io/_Private/FileDescriptorWriteHandleTrait.php
+++ b/src/io/_Private/FileDescriptorWriteHandleTrait.php
@@ -40,9 +40,4 @@ trait FileDescriptorWriteHandleTrait implements IO\WriteHandle {
       return $this->write($bytes);
     });
   }
-
-  final public function flushAsync(): Awaitable<void> {
-    // no write buffer, so just wait for end of queue.
-    return $this->queuedAsync(async () ==> {});
-  }
 }

--- a/src/io/_Private/LegacyPHPResourceHandle.php
+++ b/src/io/_Private/LegacyPHPResourceHandle.php
@@ -87,8 +87,14 @@ abstract class LegacyPHPResourceHandle implements IO\CloseableHandle {
   final public async function closeAsync(): Awaitable<void> {
     $this->checkIsValid();
     if ($this is IO\WriteHandle) {
-      await $this->flushAsync();
+      await $this->queuedAsync(async () ==> {
+        using new PHPWarningSuppressor();
+        /* HH_IGNORE_ERROR[2049] __PHPStdLib */
+        /* HH_IGNORE_ERROR[4107] __PHPStdLib */
+        \fflush($this->impl);
+      });
     }
+
     using new PHPWarningSuppressor();
     /* HH_IGNORE_ERROR[2049] __PHPStdLib */
     /* HH_IGNORE_ERROR[4107] __PHPStdLib */

--- a/src/io/_Private/LegacyPHPResourceWriteHandleTrait.php
+++ b/src/io/_Private/LegacyPHPResourceWriteHandleTrait.php
@@ -53,13 +53,4 @@ trait LegacyPHPResourceWriteHandleTrait implements IO\WriteHandle {
       return $this->write($bytes);
     });
   }
-
-  final public function flushAsync(): Awaitable<void> {
-    return $this->queuedAsync(async () ==> {
-      using new PHPWarningSuppressor();
-      /* HH_IGNORE_ERROR[2049] */
-      /* HH_IGNORE_ERROR[4107] */
-      \fflush($this->impl);
-    });
-  }
 }

--- a/tests/file/FileTest.php
+++ b/tests/file/FileTest.php
@@ -23,7 +23,6 @@ final class FileTest extends HackTest {
     $filename = sys_get_temp_dir().'/'.bin2hex(random_bytes(16));
     $f1 = File\open_write_only_nd($filename, File\WriteMode::MUST_CREATE);
     await $f1->writeAsync('Hello, world!');
-    await $f1->flushAsync();
     $e = expect(
       () ==> File\open_write_only_nd($filename, File\WriteMode::MUST_CREATE),
     )->toThrow(OS\ErrnoException::class);
@@ -57,7 +56,6 @@ final class FileTest extends HackTest {
       $b = Str\repeat('b', 10 * 1024 * 1024);
       $c = Str\repeat('c', 10 * 1024 * 1024);
       await $tf->writeAsync($a.$b.$c);
-      await $tf->flushAsync();
 
       await using ($tfr = File\open_read_only($tf->getPath()->toString())) {
         concurrent {
@@ -85,7 +83,6 @@ final class FileTest extends HackTest {
   public async function testTruncate(): Awaitable<void> {
     await using $tf = File\temporary_file();
     await $tf->writeAsync('Hello, world');
-    await $tf->flushAsync();
 
     $path = $tf->getPath()->toString();
     await using ($tfr = File\open_read_only($path)) {
@@ -105,7 +102,6 @@ final class FileTest extends HackTest {
   public async function testAppend(): Awaitable<void> {
     await using $tf = File\temporary_file();
     await $tf->writeAsync('Hello, world');
-    await $tf->flushAsync();
 
     $path = $tf->getPath()->toString();
     await using ($f = File\open_write_only($path, File\WriteMode::APPEND)) {


### PR DESCRIPTION
'flush' only makes sense for buffered IO, but Read/WriteHandles are now
unbuffered.