### PR TITLE
Provide new 'hhvm/hsl-io' virtual package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
   "require": {
     "hhvm": "^4.52",
     "hhvm/hsl": "^4.15"
+  },
+  "provide": {
+    "hhvm/hsl-io": "0.2.0"
   }
 }


### PR DESCRIPTION
This can follow SEMVER, and allows users to specify what version of
HSL-IO APIs they are compatible with, rather than new BC-incompatible releases
automatically breaking all current users (due to the library as a whole
following HHVM versioning)