### PR TITLE
[IO] Don't throw ERANGE for arguments out of range

### DIFF
--- a/src/io/MemoryHandle.php
+++ b/src/io/MemoryHandle.php
@@ -59,7 +59,7 @@ final class MemoryHandle implements SeekableReadWriteHandle {
 
   public function seek(int $pos): void {
     if ($pos < 0) {
-      _OS\throw_errno(OS\Errno::ERANGE, "Position must be >= 0");
+      _OS\throw_errno(OS\Errno::EINVAL, "Position must be >= 0");
     }
     // Past end of file is explicitly fine
     $this->offset = $pos;

--- a/src/io/ReadHandleConvenienceMethodsTrait.php
+++ b/src/io/ReadHandleConvenienceMethodsTrait.php
@@ -24,10 +24,10 @@ trait ReadHandleConvenienceMethodsTrait {
     ?int $timeout_ns = null,
   ): Awaitable<string> {
     if ($max_bytes is int && $max_bytes <= 0) {
-      _OS\throw_errno(OS\Errno::ERANGE, "Max bytes must be null, or > 0");
+      _OS\throw_errno(OS\Errno::EINVAL, "Max bytes must be null, or > 0");
     }
     if ($timeout_ns is int && $timeout_ns <= 0) {
-      _OS\throw_errno(OS\Errno::ERANGE, 'Timeout must be null, or > 0');
+      _OS\throw_errno(OS\Errno::EINVAL, 'Timeout must be null, or > 0');
     }
 
     $to_read = $max_bytes ?? Math\INT64_MAX;

--- a/src/io/WriteHandleConvenienceMethodsTrait.php
+++ b/src/io/WriteHandleConvenienceMethodsTrait.php
@@ -28,7 +28,7 @@ trait WriteHandleConvenienceMethodsTrait {
     }
 
     if ($timeout_ns is int && $timeout_ns <= 0) {
-      _OS\throw_errno(OS\Errno::ERANGE, 'Timeout must be null, or > 0');
+      _OS\throw_errno(OS\Errno::EINVAL, 'Timeout must be null, or > 0');
     }
 
     $original_size = Str\length($data);


### PR DESCRIPTION
- Was inconsistently sometimes using EINVAL, sometimes using ERANGE
- ERANGE is for *result* out of valid range, not inputs
- EINVAL allows consistent handling of errors regardless of argument
type

refs #143