### PR TITLE
Add EINVAL assertion helper, consistently use it in HSL IO

### DIFF
--- a/src/io/BufferedReader.php
+++ b/src/io/BufferedReader.php
@@ -36,12 +36,10 @@ final class BufferedReader implements IO\ReadHandle {
 
   // implementing interface
   public function read(?int $max_bytes = null): string {
-    if ($max_bytes is int && $max_bytes <= 0) {
-      _OS\throw_errno(
-        OS\Errno::EINVAL,
-        "Max bytes must be null, or greater than 0",
-      );
-    }
+    _OS\arg_assert(
+      $max_bytes is null || $max_bytes > 0,
+      "Max bytes must be null, or greater than 0",
+    );
 
     if ($this->eof) {
       return '';
@@ -68,18 +66,14 @@ final class BufferedReader implements IO\ReadHandle {
     ?int $max_bytes = null,
     ?int $timeout_ns = null,
   ): Awaitable<string> {
-    if ($max_bytes is int && $max_bytes <= 0) {
-      _OS\throw_errno(
-        OS\Errno::EINVAL,
-        "Max bytes must be null, or greater than 0",
-      );
-    }
-    if ($timeout_ns is int && $timeout_ns <= 0) {
-      _OS\throw_errno(
-        OS\Errno::EINVAL,
-        "Timeout must be null, or greater than 0",
-      );
-    }
+    _OS\arg_assert(
+      $max_bytes is null || $max_bytes > 0,
+      "Max bytes must be null, or greater than 0",
+    );
+    _OS\arg_assert(
+      $timeout_ns is null || $timeout_ns > 0,
+      "Timeout must be null, or greater than 0",
+    );
 
     if ($this->eof) {
       return '';
@@ -196,9 +190,10 @@ final class BufferedReader implements IO\ReadHandle {
   public async function readByteAsync(
     ?int $timeout_ns = null,
   ): Awaitable<string> {
-    if ($timeout_ns is int && $timeout_ns <= 0) {
-      _OS\throw_errno(OS\Errno::EINVAL, 'Timeout must be null or > 0');
-    }
+    _OS\arg_assert(
+      $timeout_ns is null || $timeout_ns > 0,
+      "Timeout must be null, or greater than 0",
+    );
     if ($this->buffer === '' && !$this->eof) {
       await $this->fillBufferAsync(null, $timeout_ns);
     }

--- a/src/io/MemoryHandle.php
+++ b/src/io/MemoryHandle.php
@@ -59,7 +59,7 @@ final class MemoryHandle implements SeekableReadWriteHandle {
 
   public function seek(int $pos): void {
     if ($pos < 0) {
-      _OS\throw_errno(OS\Errno::ERANGE, "Position must be >= 0");
+      _OS\throw_errno(OS\Errno::EINVAL, "Position must be >= 0");
     }
     // Past end of file is explicitly fine
     $this->offset = $pos;

--- a/src/io/MemoryHandle.php
+++ b/src/io/MemoryHandle.php
@@ -45,7 +45,7 @@ final class MemoryHandle implements SeekableReadWriteHandle {
 
   public function read(?int $max_bytes = null): string {
     $max_bytes ??= Math\INT64_MAX;
-    invariant($max_bytes > 0, '$max_bytes must be null or positive');
+    _OS\arg_assert($max_bytes > 0, '$max_bytes must be null or positive');
     $len = Str\length($this->buffer);
     if ($this->offset >= $len) {
       return '';
@@ -58,9 +58,7 @@ final class MemoryHandle implements SeekableReadWriteHandle {
   }
 
   public function seek(int $pos): void {
-    if ($pos < 0) {
-      _OS\throw_errno(OS\Errno::EINVAL, "Position must be >= 0");
-    }
+    _OS\arg_assert($pos >= 0, "Position must be >= 0");
     // Past end of file is explicitly fine
     $this->offset = $pos;
   }
@@ -82,7 +80,7 @@ final class MemoryHandle implements SeekableReadWriteHandle {
       return Str\length($data);
     }
 
-    invariant(
+    _OS\arg_assert(
       $this->writeMode === MemoryHandleWriteMode::OVERWRITE,
       "Write mode must be OVERWRITE or APPEND",
     );

--- a/src/io/ReadHandle.php
+++ b/src/io/ReadHandle.php
@@ -26,7 +26,7 @@ interface ReadHandle extends Handle {
    * @see `genReadAll`
    * @param $max_bytes the maximum number of bytes to read
    *   - if `null`, an internal default will be used.
-   *   - if 0, an `InvalidArgumentException` will be raised.
+   *   - if 0, `EINVAL` will be raised.
    *   - up to `$max_bytes` may be allocated in a buffer; large values may lead
    *     to unnecessarily hitting the request memory limit.
    * @throws `OS\BlockingIOException` if there is no more
@@ -46,7 +46,7 @@ interface ReadHandle extends Handle {
    * @see `genReadAll`
    * @param max_bytes the maximum number of bytes to read
    *   - if `null`, an internal default will be used.
-   *   - if 0, an `InvalidArgumentException` will be raised.
+   *   - if 0, `EINVAL` will be raised.
    *   - up to `$max_bytes` may be allocated in a buffer; large values may lead
    *     to unnecessarily hitting the request memory limit.
    * @returns

--- a/src/io/ReadHandleConvenienceMethodsTrait.php
+++ b/src/io/ReadHandleConvenienceMethodsTrait.php
@@ -24,10 +24,10 @@ trait ReadHandleConvenienceMethodsTrait {
     ?int $timeout_ns = null,
   ): Awaitable<string> {
     if ($max_bytes is int && $max_bytes <= 0) {
-      _OS\throw_errno(OS\Errno::ERANGE, "Max bytes must be null, or > 0");
+      _OS\throw_errno(OS\Errno::EINVAL, "Max bytes must be null, or > 0");
     }
     if ($timeout_ns is int && $timeout_ns <= 0) {
-      _OS\throw_errno(OS\Errno::ERANGE, 'Timeout must be null, or > 0');
+      _OS\throw_errno(OS\Errno::EINVAL, 'Timeout must be null, or > 0');
     }
 
     $to_read = $max_bytes ?? Math\INT64_MAX;

--- a/src/io/ReadHandleConvenienceMethodsTrait.php
+++ b/src/io/ReadHandleConvenienceMethodsTrait.php
@@ -23,12 +23,14 @@ trait ReadHandleConvenienceMethodsTrait {
     ?int $max_bytes = null,
     ?int $timeout_ns = null,
   ): Awaitable<string> {
-    if ($max_bytes is int && $max_bytes <= 0) {
-      _OS\throw_errno(OS\Errno::EINVAL, "Max bytes must be null, or > 0");
-    }
-    if ($timeout_ns is int && $timeout_ns <= 0) {
-      _OS\throw_errno(OS\Errno::EINVAL, 'Timeout must be null, or > 0');
-    }
+    _OS\arg_assert(
+      $max_bytes is null || $max_bytes > 0,
+      'Max bytes must be null, or > 0',
+    );
+    _OS\arg_assert(
+      $timeout_ns is null || $timeout_ns > 0,
+      'Timeout must be null, or > 0',
+    );
 
     $to_read = $max_bytes ?? Math\INT64_MAX;
 

--- a/src/io/WriteHandleConvenienceMethodsTrait.php
+++ b/src/io/WriteHandleConvenienceMethodsTrait.php
@@ -27,9 +27,10 @@ trait WriteHandleConvenienceMethodsTrait {
       return;
     }
 
-    if ($timeout_ns is int && $timeout_ns <= 0) {
-      _OS\throw_errno(OS\Errno::EINVAL, 'Timeout must be null, or > 0');
-    }
+    _OS\arg_assert(
+      $timeout_ns is null || $timeout_ns > 0,
+      'Timeout must be null, or > 0',
+    );
 
     $original_size = Str\length($data);
 

--- a/src/io/WriteHandleConvenienceMethodsTrait.php
+++ b/src/io/WriteHandleConvenienceMethodsTrait.php
@@ -28,7 +28,7 @@ trait WriteHandleConvenienceMethodsTrait {
     }
 
     if ($timeout_ns is int && $timeout_ns <= 0) {
-      _OS\throw_errno(OS\Errno::ERANGE, 'Timeout must be null, or > 0');
+      _OS\throw_errno(OS\Errno::EINVAL, 'Timeout must be null, or > 0');
     }
 
     $original_size = Str\length($data);

--- a/src/io/_Private/FileDescriptorReadHandleTrait.php
+++ b/src/io/_Private/FileDescriptorReadHandleTrait.php
@@ -20,9 +20,7 @@ trait FileDescriptorReadHandleTrait implements IO\ReadHandle {
   final public function read(?int $max_bytes = null): string {
     $max_bytes ??= DEFAULT_READ_BUFFER_SIZE;
 
-    if ($max_bytes <= 0) {
-      throw new \InvalidArgumentException('$max_bytes must be null, or >= 0');
-    }
+    _OS\arg_assert($max_bytes > 0, '$max_bytes must be null, or >= 0');
     return OS\read($this->impl, $max_bytes);
   }
 
@@ -32,12 +30,11 @@ trait FileDescriptorReadHandleTrait implements IO\ReadHandle {
   ): Awaitable<string> {
     $max_bytes ??= DEFAULT_READ_BUFFER_SIZE;
 
-    if ($max_bytes <= 0) {
-      throw new \InvalidArgumentException('$max_bytes must be null, or > 0');
-    }
-    if ($timeout_ns is int && $timeout_ns <= 0) {
-      throw new \InvalidArgumentException('$timeout_ns must be null, or >= 0');
-    }
+    _OS\arg_assert($max_bytes > 0, '$max_bytes must be null, or > 0');
+    _OS\arg_assert(
+      $timeout_ns is null || $timeout_ns > 0,
+      '$timeout_ns must be null, or >= 0',
+    );
     $timeout_ns ??= 0;
 
     try {

--- a/src/io/_Private/FileDescriptorWriteHandleTrait.php
+++ b/src/io/_Private/FileDescriptorWriteHandleTrait.php
@@ -25,9 +25,10 @@ trait FileDescriptorWriteHandleTrait implements IO\WriteHandle {
     string $bytes,
     ?int $timeout_ns = null,
   ): Awaitable<int> {
-    if ($timeout_ns is int && $timeout_ns <= 0) {
-      throw new \InvalidArgumentException('$timeout_ns must be null, or >= 0');
-    }
+    _OS\arg_assert(
+      $timeout_ns is null || $timeout_ns > 0,
+      '$timeout_ns must be null, or >= 0',
+    );
     $timeout_ns ??= 0;
 
     try {

--- a/src/io/_Private/RequestReadHandle.php
+++ b/src/io/_Private/RequestReadHandle.php
@@ -11,16 +11,15 @@
 namespace HH\Lib\_Private\_IO;
 
 use namespace HH\Lib\{IO, OS};
+use namespace HH\Lib\_Private\_OS;
 
 final class RequestReadHandle implements IO\ReadHandle {
   use IO\ReadHandleConvenienceMethodsTrait;
 
   public function read(?int $max_bytes = null): string {
-    invariant(
-      $max_bytes === null || $max_bytes > 0,
-      '$max_bytes must be null or positive',
-    );
-    return namespace\request_read($max_bytes ?? DEFAULT_READ_BUFFER_SIZE);
+    $max_bytes ??= DEFAULT_READ_BUFFER_SIZE;
+    _OS\arg_assert($max_bytes > 0, '$max_bytes must be null or positive');
+    return namespace\request_read($max_bytes);
   }
 
   public async function readAsync(

--- a/src/os/_Private/arg_assert.php
+++ b/src/os/_Private/arg_assert.php
@@ -1,0 +1,22 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\_Private\_OS;
+
+use namespace HH\Lib\{Str, OS};
+
+/** Raises EINVAL if condition is false */
+function arg_assert(bool $condition, Str\SprintfFormatString $message, mixed ...$args): void {
+  if ($condition) {
+    return;
+  }
+  /* HH_IGNORE_ERROR[4027] passing format string */
+  throw_errno(OS\Errno::EINVAL, $message, ...$args);
+}

--- a/src/os/mkostemps.php
+++ b/src/os/mkostemps.php
@@ -46,28 +46,23 @@ function mkostemps(
   int $suffix_length,
   int $flags,
 ): (FileDescriptor, string) {
-  if ($suffix_length < 0) {
-    _OS\throw_errno(Errno::EINVAL, 'Suffix length must not be negative');
-  }
-  if ($suffix_length > Str\length($template) - 6) {
-     _OS\throw_errno(Errno::EINVAL, 'Suffix length must be at most 6 less than the length of the template');
-  }
+  _OS\arg_assert($suffix_length >= 0, 'Suffix length must not be negative');
+  _OS\arg_assert(
+    Str\length($template) > $suffix_length + 6,
+    'Suffix length must be at most 6 less than the length of the template',
+  );
   if ($suffix_length === 0) {
-    if (!Str\ends_with($template, 'XXXXXX')) {
-      _OS\throw_errno(
-        Errno::EINVAL,
-        'Template must end with exactly 6 `X` characters',
-      );
-    }
+    _OS\arg_assert(
+      Str\ends_with($template, 'XXXXXX'),
+      'Template must end with exactly 6 `X` characters',
+    );
   } else if ($suffix_length > 0) {
     $base = Str\slice($template, 0, Str\length($template) - $suffix_length);
-    if (!Str\ends_with($base, 'XXXXXX')) {
-      _OS\throw_errno(
-        Errno::EINVAL,
-        'Template must be of form prefixXXXXXXsuffix - exactly 6 `X` '.
-        'characters are required',
-      );
-    }
+    _OS\arg_assert(
+      Str\ends_with($base, 'XXXXXX'),
+      'Template must be of form prefixXXXXXXsuffix - exactly 6 `X` '.
+      'characters are required',
+    );
   }
   // We do not want LightProcess to be observable.
   $flags |= O_CLOEXEC;


### PR DESCRIPTION
- Add `_OS\arg_assert($condition, $message_fmt, ...)`
- Use it to replace:
  - `if (!$argument_condition) { throw () }` when condition is not type-refining
  - `invariant()`s on arguments

In practical terms, HSL IO will now consistently raise EINVAL for bad
arguments, instead of a mix of EINVAL, InvariantException, and
InvalidArgumentException.

fixes #143 