### PR TITLE
Add `BufferedReader::linesIterator()`

### DIFF
--- a/src/io/BufferedReader.php
+++ b/src/io/BufferedReader.php
@@ -92,12 +92,14 @@ final class BufferedReader implements IO\ReadHandle {
    * The trailing suffix is read (so won't be returned by other calls), but is not
    * included in the return value.
    *
-   * This call fails with `EPIPE` if the suffix is not seen, even if there is other
+   * This call returns null if the suffix is not seen, even if there is other
    * data.
    *
-   * @see readLineAsync
+   * @see `readUntilAsyncx()` if you want to throw EPIPE instead of returning null
+   * @see `linesIterator()` if you want to iterate over all lines
+   * @see `readLineAsync()` if you want trailing data instead of null
    */
-  public async function readUntilAsync(string $suffix): Awaitable<string> {
+  public async function readUntilAsync(string $suffix): Awaitable<?string> {
     $buf = $this->buffer;
     $idx = Str\search($buf, $suffix);
     $suffix_len = Str\length($suffix);
@@ -110,11 +112,7 @@ final class BufferedReader implements IO\ReadHandle {
       $chunk = await $this->handle->readAsync();
       if ($chunk === '') {
         $this->buffer = $buf;
-        $this->eof = true;
-        throw new OS\BrokenPipeException(
-          OS\Errno::EPIPE,
-          'Reached end of file before newline',
-        );
+        return null;
       }
       $buf .= $chunk;
     } while (!Str\contains($chunk, $suffix));
@@ -125,7 +123,23 @@ final class BufferedReader implements IO\ReadHandle {
     return Str\slice($buf, 0, $idx);
   }
 
-  /** Read until the platform end-of-line sequence is seen.
+  /** Read until the suffix, or raise EPIPE if the separator is not seen.
+   *
+   * This is similar to `readUntilAsync()`, however it raises EPIPE instead
+   * of returning null.
+   */
+  public async function readUntilAsyncx(string $suffix): Awaitable<string> {
+    $ret = await $this->readUntilAsync($suffix);
+    if ($ret === null) {
+      throw new OS\BrokenPipeException(
+        OS\Errno::EPIPE,
+        'Reached end of file before newline',
+      );
+    }
+    return $ret;
+  }
+
+  /** Read until the platform end-of-line sequence is seen, or EOF is reached.
    *
    * On current platforms, this is always `\n`; it may have other values on other
    * platforms in the future, e.g. `\r\n`.
@@ -133,13 +147,62 @@ final class BufferedReader implements IO\ReadHandle {
    * The newline sequence is read (so won't be returned by other calls), but is not
    * included in the return value.
    *
-   * This call fails with `EPIPE` if "\n" not seen, even if there is other
-   * data.
+   * - Returns null if the end of file is reached with no data.
+   * - Returns a string otherwise
    *
-   * @see `readUntilAsync` for a more general form
+   * Some illustrative edge cases:
+   * - `''` is considered a 0-line input
+   * - `'foo'` is considered a 1-line input
+   * - `"foo\nbar"` is considered a 2-line input
+   * - `"foo\nbar\n"` is also considered a 2-line input
+   *
+   * @see `linesIterator()` for an iterator
+   * @see `readLineAsyncx()` to throw EPIPE instead of returning null
+   * @see `readUntilAsync()` for a more general form
    */
-  public async function readLineAsync(): Awaitable<string> {
-    return await $this->readUntilAsync("\n");
+  public async function readLineAsync(): Awaitable<?string> {
+    try {
+      $line = await $this->readUntilAsync("\n");
+    } catch (OS\ErrnoException $ex) {
+      if ($ex->getErrno() === OS\Errno::EBADF) {
+        // Eg foreach ($stdin->linesIterator()) when stdin is closed
+        return null;
+      }
+      throw $ex;
+    }
+
+    if ($line !== null) {
+      return $line;
+    }
+
+    $line = await $this->readAllAsync();
+    return $line === '' ? null : $line;
+  }
+
+  /** Read a line or throw EPIPE.
+   *
+   * @see `readLineAsync()` for details.
+   */
+  public async function readLineAsyncx(): Awaitable<string> {
+    $line = await $this->readLineAsync();
+    if ($line !== null) {
+      return $line;
+    }
+    throw new OS\BrokenPipeException(OS\Errno::EPIPE, 'No more lines to read.');
+  }
+
+  /** Iterate over all lines in the file.
+   *
+   * Usage:
+   *
+   * ```
+   * foreach ($reader->linesIterator() await as $line) {
+   *   do_stuff($line);
+   * }
+   * ```
+   */
+  public function linesIterator(): AsyncIterator<string> {
+    return new BufferedReaderLineIterator($this);
   }
 
   <<__Override>> // from trait

--- a/src/io/BufferedReader.php
+++ b/src/io/BufferedReader.php
@@ -95,7 +95,7 @@ final class BufferedReader implements IO\ReadHandle {
    * This call returns null if the suffix is not seen, even if there is other
    * data.
    *
-   * @see `readUntilAsyncx()` if you want to throw EPIPE instead of returning null
+   * @see `readUntilxAsync()` if you want to throw EPIPE instead of returning null
    * @see `linesIterator()` if you want to iterate over all lines
    * @see `readLineAsync()` if you want trailing data instead of null
    */
@@ -128,7 +128,7 @@ final class BufferedReader implements IO\ReadHandle {
    * This is similar to `readUntilAsync()`, however it raises EPIPE instead
    * of returning null.
    */
-  public async function readUntilAsyncx(string $suffix): Awaitable<string> {
+  public async function readUntilxAsync(string $suffix): Awaitable<string> {
     $ret = await $this->readUntilAsync($suffix);
     if ($ret === null) {
       throw new OS\BrokenPipeException(
@@ -157,7 +157,7 @@ final class BufferedReader implements IO\ReadHandle {
    * - `"foo\nbar\n"` is also considered a 2-line input
    *
    * @see `linesIterator()` for an iterator
-   * @see `readLineAsyncx()` to throw EPIPE instead of returning null
+   * @see `readLinexAsync()` to throw EPIPE instead of returning null
    * @see `readUntilAsync()` for a more general form
    */
   public async function readLineAsync(): Awaitable<?string> {
@@ -183,7 +183,7 @@ final class BufferedReader implements IO\ReadHandle {
    *
    * @see `readLineAsync()` for details.
    */
-  public async function readLineAsyncx(): Awaitable<string> {
+  public async function readLinexAsync(): Awaitable<string> {
     $line = await $this->readLineAsync();
     if ($line !== null) {
       return $line;

--- a/src/io/BufferedReader.php
+++ b/src/io/BufferedReader.php
@@ -133,7 +133,7 @@ final class BufferedReader implements IO\ReadHandle {
     if ($ret === null) {
       throw new OS\BrokenPipeException(
         OS\Errno::EPIPE,
-        'Reached end of file before newline',
+        'Marker/suffix not found before end of file',
       );
     }
     return $ret;

--- a/src/io/BufferedReaderLineIterator.php
+++ b/src/io/BufferedReaderLineIterator.php
@@ -1,0 +1,26 @@
+<?hh
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\IO;
+
+use namespace HH\Lib\OS;
+
+final class BufferedReaderLineIterator implements AsyncIterator<string> {
+  public function __construct(private BufferedReader $reader) {
+  }
+
+  public async function next(): Awaitable<?(mixed, string)> {
+    $line = await $this->reader->readLineAsync();
+    if ($line === null) {
+      return null;
+    }
+    return tuple(null, $line);
+  }
+}

--- a/tests/io/BufferedReaderTest.php
+++ b/tests/io/BufferedReaderTest.php
@@ -8,10 +8,11 @@
  *
  */
 
-use namespace HH\Lib\{IO, OS};
+use namespace HH\Lib\{IO, OS, Vec};
 
 use function Facebook\FBExpect\expect; // @oss-enable
 use type Facebook\HackTest\HackTest; // @oss-enable
+use type Facebook\HackTest\DataProvider; // @oss-enable
 // @oss-disable: use type HackTest;
 
 // @oss-disable: <<Oncalls('hack')>>
@@ -70,7 +71,9 @@ final class BufferedReaderTest extends HackTest {
     $r = new IO\BufferedReader(new IO\MemoryHandle("ab\ncd\nef"));
     expect(await $r->readLineAsync())->toEqual("ab");
     expect(await $r->readLineAsync())->toEqual("cd");
-    expect(async () ==> await $r->readLineAsync())->toThrow(
+    expect(await $r->readLineAsync())->toEqual("ef");
+    expect(await $r->readLineAsync())->toBeNull();
+    expect(async () ==> await $r->readLineAsyncx())->toThrow(
       OS\BrokenPipeException::class,
     );
 
@@ -80,9 +83,8 @@ final class BufferedReaderTest extends HackTest {
     expect(await $r->readAllAsync())->toEqual('ef');
 
     $r = new IO\BufferedReader(new IO\MemoryHandle('ab'));
-    expect(async () ==> await $r->readLineAsync())->toThrow(
-      OS\BrokenPipeException::class,
-    );
+    expect(await $r->readLineAsync())->toEqual('ab');
+    expect(await $r->readLineAsync())->toBeNull();
   }
 
   public async function testReadUntil(): Awaitable<void> {
@@ -103,5 +105,66 @@ final class BufferedReaderTest extends HackTest {
     $_ = await $r->readByteAsync();
     expect(await $r->readUntilAsync("FOO"))->toEqual("ab");
     expect(await $r->readUntilAsync("FOO"))->toEqual("cd");
+  }
+
+  public async function testReadLineVsReadUntil(): Awaitable<void> {
+    $r = new IO\BufferedReader(new IO\MemoryHandle("ab\ncd"));
+    expect(await $r->readLineAsync())->toEqual('ab');
+    expect(await $r->readLineAsync())->toEqual('cd');
+
+    $r = new IO\BufferedReader(new IO\MemoryHandle("ab\ncd"));
+    expect(await $r->readUntilAsync("\n"))->toEqual('ab');
+    expect(await $r->readUntilAsync("\n"))->toBeNull();
+  }
+
+  public static function provideLines(): vec<(string, vec<string>)> {
+    /* Some of these seem unintuive, but they match libc fgets() and Rust
+     * `lines()`; they also seem to match what people actually expect in
+     * practice
+     *
+     * - Hit EOL? Everything up to there is a line
+     * - Hit EOF? If we have content, it's a new line, but if not, there's
+     *   nothing.
+     */
+    return vec[
+      tuple('', vec[]), // myprog < /dev/null
+      tuple("\n", vec['']), // echo | ./myprog
+      tuple('foo', vec['foo']),
+      tuple("foo\n", vec['foo']), // echo foo | ./myprog
+      tuple("foo\nbar", vec['foo', 'bar']),
+      tuple("foo\nbar\n", vec['foo', 'bar']),
+      tuple("foo\nbar\n\n", vec['foo', 'bar', '']),
+    ];
+  }
+
+  <<DataProvider('provideLines')>>
+  public async function testIterateLines(
+    string $input,
+    vec<string> $expected_lines,
+  ): Awaitable<void> {
+    $b = new IO\BufferedReader(new IO\MemoryHandle($input));
+    $actual_lines = vec[];
+    foreach ($b->linesIterator() await as $line) {
+      $actual_lines[] = $line;
+    }
+    expect($actual_lines)->toEqual(
+      $expected_lines,
+      "Input %s",
+      \var_export($input, true),
+    );
+  }
+
+  public async function testIterateLinesOnClosedFile(): Awaitable<void> {
+    list($r, $w) = IO\pipe();
+    $r->close();
+    $w->close();
+    $b = new IO\BufferedReader($r);
+
+    $lines = vec[];
+    foreach ($b->linesIterator() await as $line) {
+      $lines[] = $line;
+    }
+    expect($lines)->toEqual(vec[]);
+
   }
 }

--- a/tests/io/BufferedReaderTest.php
+++ b/tests/io/BufferedReaderTest.php
@@ -73,7 +73,7 @@ final class BufferedReaderTest extends HackTest {
     expect(await $r->readLineAsync())->toEqual("cd");
     expect(await $r->readLineAsync())->toEqual("ef");
     expect(await $r->readLineAsync())->toBeNull();
-    expect(async () ==> await $r->readLineAsyncx())->toThrow(
+    expect(async () ==> await $r->readLinexAsync())->toThrow(
       OS\BrokenPipeException::class,
     );
 


### PR DESCRIPTION
Also:
- specialize readLine more
- make nullable vs exception-throwing versions

Iterating `while ($reader->isEndOfFile())` has several edge cases:
- file already closed (especially STDIN)
- `foo\nbar` should be `vec["foo", "bar"]`, not `"foo"` followed by
  `EPIPE`

readUntil still does exactly what it says on the tin.

The new behavior matches both C Rust IO. It's different from python,
which addresses this by including the "\n".

Going for this approach instead of the python approach as I expect
most users to just `Str\strip_suffix()`-away the trailing `\n` and not
handle the empty string.

Providing a higher-level API seems to be safer.