### PR TITLE
GitHub actions: uninstall hhvm in case of conflict

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,7 +29,7 @@ jobs:
             sudo apt-get remove hhvm
             sudo apt-get install -y hhvm-nightly
           elif [ "${{matrix.hhvm}}" = "latest" ]; then
-            sudo apt-get upgrade -y hhvm
+            sudo apt-get install -y hhvm
           else
             sudo add-apt-repository --remove https://dl.hhvm.com/ubuntu
             sudo apt-get remove hhvm

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,16 +24,14 @@ jobs:
         run: |
           set -ex
           export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update
-          sudo apt-get install -y software-properties-common apt-transport-https
-          sudo apt-key add .github/workflows/hhvm.gpg.key
           if [ "${{matrix.hhvm}}" = "nightly" ]; then
-            sudo add-apt-repository https://dl.hhvm.com/ubuntu
+            sudo apt-get remove hhvm
             sudo apt-get install -y hhvm-nightly
           elif [ "${{matrix.hhvm}}" = "latest" ]; then
-            sudo add-apt-repository https://dl.hhvm.com/ubuntu
-            sudo apt-get install -y hhvm
+            sudo apt-get ugprade -y hhvm
           else
+            sudo add-apt-repository --remove https://dl.hhvm.com/ubuntu
+            sudo apt-get remove hhvm
             DISTRO=$(lsb_release --codename --short)
             sudo add-apt-repository \
               "deb https://dl.hhvm.com/ubuntu ${DISTRO}-${{matrix.hhvm}} main"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           set -ex
           export DEBIAN_FRONTEND=noninteractive
+          sudo add-apt-repository https://dl.hhvm.com/ubuntu
           if [ "${{matrix.hhvm}}" = "nightly" ]; then
             sudo apt-get remove hhvm
             sudo apt-get install -y hhvm-nightly

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
             sudo apt-get remove hhvm
             sudo apt-get install -y hhvm-nightly
           elif [ "${{matrix.hhvm}}" = "latest" ]; then
-            sudo apt-get ugprade -y hhvm
+            sudo apt-get upgrade -y hhvm
           else
             sudo add-apt-repository --remove https://dl.hhvm.com/ubuntu
             sudo apt-get remove hhvm


### PR DESCRIPTION
GitHub Actions' Ubuntu 20.04 has HHVM 4.62 pre-installed. We need
to remove it before we can install a specific version.