### PR TITLE
Update requirements to 4.58

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ ubuntu , macos ]
         hhvm:
-          - 4.52
+          - 4.58
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.52-latest
+- HHVM_VERSION=4.58-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 install:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "hhvm/hhvm-autoload": "^2.0|^3.0"
   },
   "require": {
-    "hhvm": "^4.52",
+    "hhvm": "^4.58",
     "hhvm/hsl": "^4.15"
   },
   "provide": {


### PR DESCRIPTION
Failing on 4.52 on both platforms

- fails on 4.57
- 4.58 is the first release with ce210a2596bbe33c0526fcb926a8bb559df3d206

Test Plan:

TravisCI and GitHub actions
