### PR TITLE
Add OS\mkdtemp

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ ubuntu , macos ]
         hhvm:
-          - 4.58
+          - 4.59
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.58-latest
+- HHVM_VERSION=4.59-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 install:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "hhvm/hhvm-autoload": "^2.0|^3.0"
   },
   "require": {
-    "hhvm": "^4.58",
+    "hhvm": "^4.59",
     "hhvm/hsl": "^4.15"
   },
   "provide": {

--- a/src/os/mkdtemp.php
+++ b/src/os/mkdtemp.php
@@ -1,0 +1,39 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\OS;
+
+use namespace HH\Lib\Str;
+use namespace HH\Lib\_Private\_OS;
+
+/** Create a temporary directory.
+ *
+ * This function creates a new, unique temporary directory, with the name
+ * matching the provided template, and returns the path. The directory will be
+ * created with permissions 0700.
+ *
+ * The template MUST end with `XXXXXX`; these are replaced with random
+ * printable characters to create a unique name. While some platforms are more
+ * flexible, the HSL always requires this for consistency. Any additional
+ * trailing `X`s may result in literal X's (e.g. glibc), or in additional
+ * randomness (e.g. BSD) - use a separator (e.g. `fooXXX.XXXXXX`) to guarantee
+ * any characters are preserved.
+ */
+function mkdtemp(string $template): string {
+  // This restriction exists with glibc, but BSD (e.g. MacOS) is more flexible;
+  // don't let people accidentally write non-portable code.
+  if (!Str\ends_with($template, 'XXXXXX')) {
+    _OS\throw_errno(
+      Errno::EINVAL,
+      "mkdtemp template must always end with 'XXXXXX' (portability)",
+    );
+  }
+  return _OS\wrap_impl(() ==> _OS\mkdtemp($template));
+}

--- a/tests/os/MkdtempTest.php
+++ b/tests/os/MkdtempTest.php
@@ -1,0 +1,47 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use namespace HH\Lib\{IO, OS, Str};
+
+use function Facebook\FBExpect\expect; // @oss-enable
+use type Facebook\HackTest\HackTest; // @oss-enable
+// @oss-disable: use type HackTest;
+
+// @oss-disable: <<Oncalls('hack')>>
+final class MkdtempTest extends HackTest {
+  public function testBasicUsage(): void {
+    $pattern = Str\strip_suffix(sys_get_temp_dir(), '/').'/hsl-test-XXXXXX';
+    $tempdir = OS\mkdtemp($pattern);
+    expect($tempdir)->toNotEqual(
+      $pattern,
+      'expected literal `X` to be replaced',
+    );
+    $prefix = Str\strip_suffix($pattern, 'XXXXXX');
+    expect(Str\starts_with($tempdir, $prefix))->toBeTrue(
+      'tempdir and pattern do not share a prefix',
+    );
+    expect(is_dir($tempdir))->toBeTrue();
+    expect((stat($tempdir)['mode']) & 0777)->toEqual(0700);
+    rmdir($tempdir);
+  }
+
+  public function testTooFewPlaceholders(): void {
+    $pattern = Str\strip_suffix(sys_get_temp_dir(), '/').'/hsl-test-XXX';
+    $ex = expect(() ==> OS\mkdtemp($pattern))->toThrow(
+      OS\ErrnoException::class,
+    );
+    expect($ex->getErrno())->toEqual(OS\Errno::EINVAL);
+  }
+
+  public function testNoParentDirectory(): void {
+    $pattern = '/idonotexist/foo.XXXXXX';
+    expect(() ==> OS\mkdtemp($pattern))->toThrow(OS\NotFoundException::class);
+  }
+}


### PR DESCRIPTION
I don't usually add tests for `OS\` given they're almost entirely tested
by the HHVM built-in tests, and by `File\`, `TCP\`, `UDP\` etc; I'm
adding one here given that it's not yet clear what the higher-level API
(if any) will be, so there isn't any coverage there.