### PR TITLE
Run github actions jobs daily

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,9 @@
 name: Continuous Integration
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 15 * * *'
 jobs:
   build:
     name: HHVM ${{matrix.hhvm}} - ${{matrix.os}}


### PR DESCRIPTION
Gives us MacOS tests against nightly builds even when there's no
changes to hsl-experimental
