### PR TITLE
Add CloseableHandle::closeWhenDisposed()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
     "hhvm/hsl": "^4.15"
   },
   "provide": {
-    "hhvm/hsl-io": "0.2.0"
+    "hhvm/hsl-io": "0.2.1"
   }
 }

--- a/src/io/CloseableHandle.php
+++ b/src/io/CloseableHandle.php
@@ -19,4 +19,11 @@ namespace HH\Lib\IO;
 interface CloseableHandle extends Handle {
   /** Close the handle */
   public function close(): void;
+
+  /** Close the handle when the returned disposable is disposed.
+   *
+   * Usage: `using $handle->closeWhenDisposed();`
+   */
+  <<__ReturnDisposable>>
+  public function closeWhenDisposed(): \IDisposable;
 }

--- a/src/io/MemoryHandle.php
+++ b/src/io/MemoryHandle.php
@@ -11,7 +11,7 @@
 namespace HH\Lib\IO;
 
 use namespace HH\Lib\{Math, OS, Str};
-use namespace HH\Lib\_Private\_OS;
+use namespace HH\Lib\_Private\{_IO, _OS};
 
 enum MemoryHandleWriteMode: int {
   OVERWRITE = 0;
@@ -40,6 +40,11 @@ final class MemoryHandle implements CloseableSeekableReadWriteHandle {
   public function close(): void {
     $this->open = false;
     $this->offset = -1;
+  }
+
+  <<__ReturnDisposable>>
+  public function closeWhenDisposed(): \IDisposable {
+    return new _IO\CloseWhenDisposed($this);
   }
 
   public async function readAsync(

--- a/src/io/_Private/CloseWhenDisposed.php
+++ b/src/io/_Private/CloseWhenDisposed.php
@@ -1,0 +1,24 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\_Private\_IO;
+
+use namespace HH\Lib\IO;
+
+final class CloseWhenDisposed implements \IDisposable {
+  public function __construct(
+    private IO\CloseableHandle $handle,
+  ) {
+  }
+
+  public function __dispose(): void {
+    $this->handle->close();
+  }
+}

--- a/src/io/_Private/FileDescriptorHandle.php
+++ b/src/io/_Private/FileDescriptorHandle.php
@@ -11,7 +11,7 @@
 namespace HH\Lib\_Private\_IO;
 
 use namespace HH\Lib\{IO, OS, Str};
-use namespace HH\Lib\_Private\_OS;
+use namespace HH\Lib\_Private\{_IO, _OS};
 
 abstract class FileDescriptorHandle implements IO\CloseableHandle, IO\FDHandle {
   protected bool $isAwaitable = true;
@@ -51,5 +51,10 @@ abstract class FileDescriptorHandle implements IO\CloseableHandle, IO\FDHandle {
 
   final public function close(): void {
     OS\close($this->impl);
+  }
+
+  <<__ReturnDisposable>>
+  final public function closeWhenDisposed(): \IDisposable {
+    return new _IO\CloseWhenDisposed($this);
   }
 }

--- a/tests/io/MemoryHandleTest.php
+++ b/tests/io/MemoryHandleTest.php
@@ -30,6 +30,15 @@ final class MemoryHandleTest extends HackTest {
     expect(await $h->readAllAsync())->toEqual('derp');
   }
 
+  public function testCloseWhenDisposed(): void {
+    $h = new IO\MemoryHandle('foobar');
+    using ($h->closeWhenDisposed()) {
+      expect($h->read(3))->toEqual('foo');
+    }
+    $ex = expect(() ==> $h->read(3))->toThrow(OS\ErrnoException::class);
+    expect($ex->getErrno())->toEqual(OS\Errno::EBADF);
+  }
+
   public async function testReadAtInvalidOffset(): Awaitable<void> {
     $h = new IO\MemoryHandle('herpderp');
     $h->seek(99999);


### PR DESCRIPTION
If not used and `close()` is not called, handles will be closed at some
undefined later time, e.g. end of request or when garabage collected.

No current implementation is refcount-based.
