### PR TITLE
Handle files being manually closed before __dispose

### DIFF
--- a/src/file/Lock.php
+++ b/src/file/Lock.php
@@ -26,6 +26,12 @@ final class Lock implements \IDisposable {
   }
 
   final public function __dispose(): void {
-    _OS\flock($this->fd, _OS\LOCK_UN);
+    try {
+      OS\flock($this->fd, _OS\LOCK_UN);
+    } catch (OS\ErrnoException $e) {
+      if ($e->getErrno() !== OS\Errno::EBADF) {
+        throw $e;
+      }
+    }
   }
 }

--- a/src/file/TemporaryFile.php
+++ b/src/file/TemporaryFile.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\File;
 
-use namespace HH\Lib\IO;
+use namespace HH\Lib\{IO, OS};
 use namespace HH\Lib\_Private\_IO;
 
 final class TemporaryFile implements \IDisposable {
@@ -21,7 +21,13 @@ final class TemporaryFile implements \IDisposable {
   }
   public function __dispose(): void {
     $f = $this->getHandle();
-    $f->close();
+    try {
+      $f->close();
+    } catch (OS\ErrnoException $e) {
+      if ($e->getErrno() !== OS\Errno::EBADF) {
+        throw $e;
+      }
+    }
     /* HH_IGNORE_ERROR[2049] __PHPStdLib */
     /* HH_IGNORE_ERROR[4107] __PHPStdLib */
     \unlink($f->getPath()->toString());

--- a/tests/file/FileTest.php
+++ b/tests/file/FileTest.php
@@ -184,4 +184,14 @@ final class FileTest extends HackTest {
       $f4->close();
     }
   }
+
+  public function testEarlyClosedDisposables(): void {
+    using $tf = File\temporary_file();
+    using ($tf->getHandle()->tryLockx(File\LockType::SHARED)) {
+      $tf->getHandle()->close();
+    }
+    // Expectations:
+    // - the lock's __dispose didn't throw
+    // - the temporary file's __dispose didn't throw
+  }
 }


### PR DESCRIPTION
In particular:
- closing files with locks makes sense
- closing temporary files before passing the filename to
subprocess - but before unlinking - is a common pattern

fixes #160
