### PR TITLE
Update minimum version to 4.66

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu , macos ]
         hhvm:
-          - 4.59
+          - 4.66
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.59-latest
+- HHVM_VERSION=4.66-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 install:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "hhvm/hhvm-autoload": "^2.0|^3.0"
   },
   "require": {
-    "hhvm": "^4.59",
+    "hhvm": "^4.66",
     "hhvm/hsl": "^4.15"
   },
   "provide": {


### PR DESCRIPTION
Needed for `OS\isatty()` and `OS\ttyname()`
