### PR TITLE
Fix `readUntilAsync`/`genReadUntil` across chunk boundaries

### DIFF
--- a/src/io/BufferedReader.php
+++ b/src/io/BufferedReader.php
@@ -12,7 +12,7 @@
 
 namespace HH\Lib\IO;
 
-use namespace HH\Lib\{IO, OS, Str};
+use namespace HH\Lib\{IO, Math, OS, Str};
 use namespace HH\Lib\_Private\_OS;
 
 /** Wrapper for `ReadHandle`s, with buffered line-based byte-based accessors.
@@ -109,13 +109,16 @@ final class BufferedReader implements IO\ReadHandle {
     }
 
     do {
+      // + 1 as it would have been matched in the previous iteration if it
+      // fully fit in the chunk
+      $offset = Math\maxva(0, Str\length($buf) - $suffix_len + 1);
       $chunk = await $this->handle->readAsync();
       if ($chunk === '') {
         $this->buffer = $buf;
         return null;
       }
       $buf .= $chunk;
-    } while (!Str\contains($chunk, $suffix));
+    } while (!Str\contains($buf, $suffix, $offset));
 
     $idx = Str\search($buf, $suffix);
     invariant($idx !== null, 'Should not have exited loop without suffix');


### PR DESCRIPTION
fixes hhvm/hsl-experimental#166

Test Plan:

- added unit test
- if I revert the code change, test fails
- if I revert the code chaange and replace the `- 1` in the test with
  `- 2`, it passes
