### PR TITLE
Remove redundant call to invariant

### DIFF
--- a/src/io/BufferedReader.php
+++ b/src/io/BufferedReader.php
@@ -121,7 +121,6 @@ final class BufferedReader implements IO\ReadHandle {
       $idx = Str\search($buf, $suffix, $offset);
     } while ($idx === null);
 
-    invariant($idx !== null, 'Should not have exited loop without suffix');
     $this->buffer = Str\slice($buf, $idx + $suffix_len);
     return Str\slice($buf, 0, $idx);
   }


### PR DESCRIPTION
The while loop will spin until $idx is nonnull.
This invariant was needed previously, but a recent commit changed the code in such a way that the typechecker can understand this invariant.