### PR TITLE
s/public function write/protected function writeImpl/

### DIFF
--- a/src/io/MemoryHandle.php
+++ b/src/io/MemoryHandle.php
@@ -83,7 +83,7 @@ final class MemoryHandle implements CloseableSeekableReadWriteHandle {
     return $this->offset;
   }
 
-  public function write(string $data): int {
+  protected function writeImpl(string $data): int {
     $this->checkIsOpen();
     $length = Str\length($this->buffer);
     if ($length < $this->offset) {
@@ -116,7 +116,7 @@ final class MemoryHandle implements CloseableSeekableReadWriteHandle {
     string $data,
     ?int $timeout_nanos = null,
   ): Awaitable<int> {
-    return $this->write($data);
+    return $this->writeImpl($data);
   }
 
   public function getBuffer(): string {

--- a/src/io/WriteHandle.php
+++ b/src/io/WriteHandle.php
@@ -15,20 +15,19 @@ use namespace HH\Lib\_Private;
 
 /** An interface for a writable Handle.
  *
- * Order of operations is guaranteed, *except* for `rawWriteBlocking`;
- * `rawWriteBlocking()` will immediately try to write to the handle.
+ * Order of operations is guaranteed, *except* for `writeImplBlocking`;
+ * `writeImplBlocking()` will immediately try to write to the handle.
  */
 interface WriteHandle extends Handle {
   /** An immediate unordered write.
    *
+   * @see `writeAllAsync()`
    * @see `writeAllowPartialSuccessAsync()`
    * @throws `OS\BlockingIOException` if the handle is a socket or similar,
    *   and the write would block.
-   * @returns the number of bytes written on success
-   *
-   * Returns the number of bytes written, which may be 0.
+   * @returns the number of bytes written on success, which may be 0
    */
-  public function write(string $bytes): int;
+  protected function writeImpl(string $bytes): int;
 
   /** Write data, waiting if necessary.
    *

--- a/src/io/_Private/FileDescriptorWriteHandleTrait.php
+++ b/src/io/_Private/FileDescriptorWriteHandleTrait.php
@@ -17,7 +17,7 @@ trait FileDescriptorWriteHandleTrait implements IO\WriteHandle {
   require extends FileDescriptorHandle;
   use IO\WriteHandleConvenienceMethodsTrait;
 
-  final public function write(string $bytes): int {
+  final protected function writeImpl(string $bytes): int {
     return OS\write($this->impl, $bytes);
   }
 
@@ -32,11 +32,11 @@ trait FileDescriptorWriteHandleTrait implements IO\WriteHandle {
     $timeout_ns ??= 0;
 
     try {
-      return $this->write($bytes);
+      return $this->writeImpl($bytes);
     } catch (OS\BlockingIOException $_) {
       // We need to wait, which we do below...
     }
     await $this->selectAsync(\STREAM_AWAIT_WRITE, $timeout_ns);
-    return $this->write($bytes);
+    return $this->writeImpl($bytes);
   }
 }

--- a/src/io/_Private/ResponseWriteHandle.php
+++ b/src/io/_Private/ResponseWriteHandle.php
@@ -15,7 +15,7 @@ use namespace HH\Lib\{IO, OS};
 final class ResponseWriteHandle implements IO\WriteHandle {
   use IO\WriteHandleConvenienceMethodsTrait;
 
-  public function write(string $bytes): int {
+  protected function writeImpl(string $bytes): int {
     return namespace\response_write($bytes);
   }
 
@@ -23,6 +23,6 @@ final class ResponseWriteHandle implements IO\WriteHandle {
     string $bytes,
     ?int $_timeout_ns = null,
   ): Awaitable<int> {
-    return $this->write($bytes);
+    return $this->writeImpl($bytes);
   }
 }

--- a/tests/io/MemoryHandleTest.php
+++ b/tests/io/MemoryHandleTest.php
@@ -52,20 +52,19 @@ final class MemoryHandleTest extends HackTest {
     );
   }
 
-  public function testWrite(): void {
+  public async function testWrite(): Awaitable<void> {
     $h = new IO\MemoryHandle();
-    $h->write('herp');
+    await $h->writeAllowPartialSuccessAsync('herp');
     expect($h->getBuffer())->toEqual('herp');
-    $h->write('derp');
-    expect($h->getBuffer())->toEqual('herpderp');
+    await $h->writeAllowPartialSuccessAsync('derp');
     $h->reset();
-    $h->write('foo');
+    await $h->writeAllowPartialSuccessAsync('foo');
     expect($h->getBuffer())->toEqual('foo');
   }
 
   public async function testOverwrite(): Awaitable<void> {
     $h = new IO\MemoryHandle('xxxxderp');
-    $h->write('herp');
+    await $h->writeAllowPartialSuccessAsync('herp');
     expect($h->getBuffer())->toEqual('herpderp');
     expect(await $h->readAllAsync())->toEqual('derp');
     $h->seek(0);
@@ -74,7 +73,7 @@ final class MemoryHandleTest extends HackTest {
 
   public async function testAppend(): Awaitable<void> {
     $h = new IO\MemoryHandle('herp', IO\MemoryHandleWriteMode::APPEND);
-    $h->write('derp');
+    await $h->writeAllowPartialSuccessAsync('derp');
     expect($h->getBuffer())->toEqual('herpderp');
     expect(await $h->readAllAsync())->toEqual('');
     $h->seek(0);
@@ -97,7 +96,7 @@ final class MemoryHandleTest extends HackTest {
     $ex = expect(() ==> $h->read(1024))->toThrow(OS\ErrnoException::class);
     expect($ex->getErrno())->toEqual(OS\Errno::EBADF);
     $h->reset('herp');
-    $h->write('derp');
+    await $h->writeAllowPartialSuccessAsync('derp');
     $h->seek(0);
     expect($h->read(1024))->toEqual('herpderp');
   }


### PR DESCRIPTION
- rename: make it clear that it's only an implementation detail; users
  should only use the async functions writeAllAsync or
  writeAllowPartialSuccessAsync
- make it protected: given it's the only non-awaitable writer, it's
  still too tempting, and unneccessary

I'm not aware of any edge cases, but if they exist,
`getFileDescriptor()` can be used in combination with `OS\write()`. This

Will follow up with a similar change to `read()`

refs #173
