### PR TITLE
Rename read() to readImpl()

### DIFF
--- a/src/io/BufferedReader.php
+++ b/src/io/BufferedReader.php
@@ -35,7 +35,7 @@ final class BufferedReader implements IO\ReadHandle {
   private string $buffer = '';
 
   // implementing interface
-  public function read(?int $max_bytes = null): string {
+  public function readImpl(?int $max_bytes = null): string {
     _OS\arg_assert(
       $max_bytes is null || $max_bytes > 0,
       "Max bytes must be null, or greater than 0",
@@ -45,7 +45,7 @@ final class BufferedReader implements IO\ReadHandle {
       return '';
     }
     if ($this->buffer === '') {
-      $this->buffer = $this->getHandle()->read();
+      $this->buffer = $this->getHandle()->readImpl();
       if ($this->buffer === '') {
         $this->eof = true;
         return '';
@@ -84,7 +84,7 @@ final class BufferedReader implements IO\ReadHandle {
 
     // We either have a buffer, or reached EOF; either way, behavior matches
     // read, so just delegate
-    return $this->read($max_bytes);
+    return $this->readImpl($max_bytes);
   }
 
   /** Read until the specified suffix is seen.
@@ -301,7 +301,7 @@ final class BufferedReader implements IO\ReadHandle {
       // Calling the non-async (but still non-blocking) version as the async
       // version could wait for the other end to send data - which could lead
       // to both ends of a pipe/socket waiting on each other.
-      $this->buffer = $this->handle->read();
+      $this->buffer = $this->handle->readImpl();
       if ($this->buffer === '') {
         $this->eof = true;
         return true;

--- a/src/io/MemoryHandle.php
+++ b/src/io/MemoryHandle.php
@@ -51,10 +51,10 @@ final class MemoryHandle implements CloseableSeekableReadWriteHandle {
     ?int $max_bytes = null,
     ?int $_timeout_nanos = null,
   ): Awaitable<string> {
-    return $this->read($max_bytes);
+    return $this->readImpl($max_bytes);
   }
 
-  public function read(?int $max_bytes = null): string {
+  public function readImpl(?int $max_bytes = null): string {
     $this->checkIsOpen();
 
     $max_bytes ??= Math\INT64_MAX;

--- a/src/io/ReadHandle.php
+++ b/src/io/ReadHandle.php
@@ -36,7 +36,7 @@ interface ReadHandle extends Handle {
    *   - the read data on success.
    *   - the empty string if the end of file is reached.
    */
-  public function read(?int $max_bytes = null): string;
+  public function readImpl(?int $max_bytes = null): string;
 
   /** Read from the handle, waiting for data if necessary.
    *

--- a/src/io/_Private/FileDescriptorReadHandleTrait.php
+++ b/src/io/_Private/FileDescriptorReadHandleTrait.php
@@ -17,7 +17,7 @@ trait FileDescriptorReadHandleTrait implements IO\ReadHandle {
   require extends FileDescriptorHandle;
   use IO\ReadHandleConvenienceMethodsTrait;
 
-  final public function read(?int $max_bytes = null): string {
+  final public function readImpl(?int $max_bytes = null): string {
     $max_bytes ??= DEFAULT_READ_BUFFER_SIZE;
 
     _OS\arg_assert($max_bytes > 0, '$max_bytes must be null, or > 0');
@@ -38,12 +38,12 @@ trait FileDescriptorReadHandleTrait implements IO\ReadHandle {
     $timeout_ns ??= 0;
 
     try {
-      return $this->read($max_bytes);
+      return $this->readImpl($max_bytes);
     } catch (OS\BlockingIOException $_) {
       // this means we need to wait for data, which we do below...
     }
 
     await $this->selectAsync(\STREAM_AWAIT_READ, $timeout_ns);
-    return $this->read($max_bytes);
+    return $this->readImpl($max_bytes);
   }
 }

--- a/src/io/_Private/RequestReadHandle.php
+++ b/src/io/_Private/RequestReadHandle.php
@@ -16,7 +16,7 @@ use namespace HH\Lib\_Private\_OS;
 final class RequestReadHandle implements IO\ReadHandle {
   use IO\ReadHandleConvenienceMethodsTrait;
 
-  public function read(?int $max_bytes = null): string {
+  public function readImpl(?int $max_bytes = null): string {
     $max_bytes ??= DEFAULT_READ_BUFFER_SIZE;
     _OS\arg_assert($max_bytes > 0, '$max_bytes must be null or positive');
     return namespace\request_read($max_bytes);
@@ -26,6 +26,6 @@ final class RequestReadHandle implements IO\ReadHandle {
     ?int $max_bytes = null,
     ?int $timeout_ns = null,
   ): Awaitable<string> {
-    return $this->read($max_bytes);
+    return $this->readImpl($max_bytes);
   }
 }

--- a/tests/io/BufferedReaderTest.php
+++ b/tests/io/BufferedReaderTest.php
@@ -30,7 +30,7 @@ final class BufferedReaderTest extends HackTest {
 
     $r = new IO\BufferedReader(new IO\MemoryHandle('abcdef'));
     expect(await $r->readByteAsync())->toEqual('a');
-    expect($r->read(2))->toEqual('bc');
+    expect(await $r->readFixedSizeAsync(2))->toEqual('bc');
     expect(await $r->readAllowPartialSuccessAsync(2))->toEqual('de');
     expect(await $r->readByteAsync())->toEqual('f');
 
@@ -55,13 +55,13 @@ final class BufferedReaderTest extends HackTest {
 
     $r = new IO\BufferedReader(new IO\MemoryHandle('abcdef'));
     expect(await $r->readFixedSizeAsync(2))->toEqual('ab');
-    expect($r->read(2))->toEqual('cd');
+    expect(await $r->readFixedSizeAsync(2))->toEqual('cd');
     expect(await $r->readFixedSizeAsync(2))->toEqual('ef');
   }
 
   public async function testReadTooMuch(): Awaitable<void> {
     $newbuf = () ==> new IO\BufferedReader(new IO\MemoryHandle('abc'));
-    expect($newbuf()->read(6))->toEqual('abc');
+    expect(await $newbuf()->readAllAsync(6))->toEqual('abc');
     expect(await $newbuf()->readAllowPartialSuccessAsync(6))->toEqual('abc');
     expect(async () ==> await $newbuf()->readFixedSizeAsync(6))->toThrow(
       OS\BrokenPipeException::class,


### PR DESCRIPTION
Unlike writeImpl() in https://github.com/hhvm/hsl-experimental/pull/174,
I've kept this public - BufferedReader is a compelling reason to keep
it.

fixes #173
