### PR TITLE
[IO] fix offset out-of-bounds issue in memory handle

### DIFF
--- a/src/io/MemoryHandle.php
+++ b/src/io/MemoryHandle.php
@@ -105,7 +105,10 @@ final class MemoryHandle implements CloseableSeekableReadWriteHandle {
     $data_length = Str\length($data);
     $new = Str\slice($this->buffer, 0, $this->offset).$data;
     if ($this->offset < $length) {
-      $new .= Str\slice($this->buffer, $this->offset + $data_length);
+      $new .= Str\slice(
+        $this->buffer,
+        Math\minva($this->offset + $data_length, $length),
+      );
     }
     $this->buffer = $new;
     $this->offset += $data_length;

--- a/tests/io/MemoryHandleTest.php
+++ b/tests/io/MemoryHandleTest.php
@@ -16,6 +16,22 @@ use type Facebook\HackTest\HackTest; // @oss-enable
 
 // @oss-disable: <<Oncalls('hack')>>
 final class MemoryHandleTest extends HackTest {
+  public async function testWriteOverwriteOutOfBound(): Awaitable<void> {
+    $handle = new IO\MemoryHandle('f', IO\MemoryHandleWriteMode::OVERWRITE);
+
+    await $handle->writeAllAsync('Hello, World!');
+
+    expect($handle->getBuffer())->toEqual('Hello, World!');
+  }
+
+  public async function testWriteAppendOutOfBound(): Awaitable<void> {
+    $handle = new IO\MemoryHandle('f', IO\MemoryHandleWriteMode::APPEND);
+
+    await $handle->writeAllAsync('Hello, World!');
+
+    expect($handle->getBuffer())->toEqual('fHello, World!');
+  }
+
   public async function testRead(): Awaitable<void> {
     $h = new IO\MemoryHandle('herpderp');
     expect(await $h->readFixedSizeAsync(4))->toEqual('herp');


### PR DESCRIPTION
I have added a test to reproduce the bug.
