### PR TITLE
DO NOT COMMIT: move HH\Lib\OS to HH\Staging\OS

### DIFF
--- a/src/file/Lock.php
+++ b/src/file/Lock.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\File;
 
-use namespace HH\Lib\{OS, _Private\_OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{_Private\_OS};
 
 /**
  * A File Lock, which is unlocked as a disposable. To acquire one, call `lock`

--- a/src/file/LockType.php
+++ b/src/file/LockType.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\File;
 
-use namespace HH\Lib\OS;
+use namespace HH\Staging\OS;
 
 enum LockType: int as int {
   /**

--- a/src/file/TemporaryFile.php
+++ b/src/file/TemporaryFile.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\File;
 
-use namespace HH\Lib\{IO, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO};
 use namespace HH\Lib\_Private\_IO;
 
 final class TemporaryFile implements \IDisposable {

--- a/src/file/WriteMode.php
+++ b/src/file/WriteMode.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\File;
 
-use namespace HH\Lib\OS;
+use namespace HH\Staging\OS;
 
 enum WriteMode: int {
   /**

--- a/src/file/_Private/CloseableFileHandle.php
+++ b/src/file/_Private/CloseableFileHandle.php
@@ -12,7 +12,8 @@ namespace HH\Lib\_Private\_File;
 
 use namespace HH\Lib\Str;
 use namespace HH\Lib\_Private\{_IO, _OS};
-use namespace HH\Lib\{IO, File, OS};
+use namespace HH\Lib\{IO, File};
+use namespace HH\Staging\OS;
 
 <<__ConsistentConstruct>>
 abstract class CloseableFileHandle

--- a/src/file/open.php
+++ b/src/file/open.php
@@ -9,7 +9,8 @@
  */
 
 namespace HH\Lib\File;
-use namespace HH\Lib\{OS, _Private\_File};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{_Private\_File};
 
 function open_read_only(string $path): CloseableReadHandle {
   return OS\open($path, OS\O_RDONLY)

--- a/src/file/temporary_file.php
+++ b/src/file/temporary_file.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\File;
 
-use namespace HH\Lib\{OS, Str};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{Str};
 use namespace HH\Lib\_Private\_File;
 
 /** Create a new temporary file.

--- a/src/io/BufferedReader.php
+++ b/src/io/BufferedReader.php
@@ -12,7 +12,8 @@
 
 namespace HH\Lib\IO;
 
-use namespace HH\Lib\{IO, Math, OS, Str};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO, Math, Str};
 use namespace HH\Lib\_Private\_OS;
 
 /** Wrapper for `ReadHandle`s, with buffered line-based byte-based accessors.

--- a/src/io/BufferedReaderLineIterator.php
+++ b/src/io/BufferedReaderLineIterator.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\IO;
 
-use namespace HH\Lib\OS;
+use namespace HH\Staging\OS;
 
 final class BufferedReaderLineIterator implements AsyncIterator<string> {
   public function __construct(private BufferedReader $reader) {

--- a/src/io/MemoryHandle.php
+++ b/src/io/MemoryHandle.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\IO;
 
-use namespace HH\Lib\{Math, OS, Str};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{Math, Str};
 use namespace HH\Lib\_Private\{_IO, _OS};
 
 enum MemoryHandleWriteMode: int {

--- a/src/io/ReadHandleConvenienceMethodsTrait.php
+++ b/src/io/ReadHandleConvenienceMethodsTrait.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\IO;
 
-use namespace HH\Lib\{Math, Str, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{Math, Str};
 use namespace HH\Lib\_Private\{_IO, _OS};
 
 /** Trait implementing `ReadHandle` methods that can be implemented in terms

--- a/src/io/WriteHandleConvenienceMethodsTrait.php
+++ b/src/io/WriteHandleConvenienceMethodsTrait.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\IO;
 
-use namespace HH\Lib\{Str, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{Str};
 use namespace HH\Lib\_Private\_OS;
 
 /** Trait implementing `WriteHandle` methods that can be implemented in terms

--- a/src/io/_Private/FileDescriptorHandle.php
+++ b/src/io/_Private/FileDescriptorHandle.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\{IO, OS, Str};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO, Str};
 use namespace HH\Lib\_Private\{_IO, _OS};
 
 abstract class FileDescriptorHandle implements IO\CloseableHandle, IO\FDHandle {

--- a/src/io/_Private/FileDescriptorReadHandleTrait.php
+++ b/src/io/_Private/FileDescriptorReadHandleTrait.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\{IO, Str, OS, Math};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO, Str, Math};
 use namespace HH\Lib\_Private\_OS;
 
 trait FileDescriptorReadHandleTrait implements IO\ReadHandle {

--- a/src/io/_Private/FileDescriptorWriteHandleTrait.php
+++ b/src/io/_Private/FileDescriptorWriteHandleTrait.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\{IO, Math, OS, Str};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO, Math, Str};
 use namespace HH\Lib\_Private\_OS;
 
 trait FileDescriptorWriteHandleTrait implements IO\WriteHandle {

--- a/src/io/_Private/PipeReadHandle.php
+++ b/src/io/_Private/PipeReadHandle.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\{IO, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO};
 
 final class PipeReadHandle
   extends FileDescriptorHandle

--- a/src/io/_Private/PipeWriteHandle.php
+++ b/src/io/_Private/PipeWriteHandle.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\{IO, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO};
 
 final class PipeWriteHandle
   extends FileDescriptorHandle

--- a/src/io/_Private/RequestReadHandle.php
+++ b/src/io/_Private/RequestReadHandle.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\{IO, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO};
 use namespace HH\Lib\_Private\_OS;
 
 final class RequestReadHandle implements IO\ReadHandle {

--- a/src/io/_Private/ResponseWriteHandle.php
+++ b/src/io/_Private/ResponseWriteHandle.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\{IO, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO};
 
 final class ResponseWriteHandle implements IO\WriteHandle {
   use IO\WriteHandleConvenienceMethodsTrait;

--- a/src/io/_Private/StdioReadHandle.php
+++ b/src/io/_Private/StdioReadHandle.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\{IO, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO};
 
 final class StdioReadHandle
   extends FileDescriptorHandle

--- a/src/io/_Private/StdioWriteHandle.php
+++ b/src/io/_Private/StdioWriteHandle.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\_Private\_IO;
 
-use namespace HH\Lib\{IO, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO};
 
 final class StdioWriteHandle
   extends FileDescriptorHandle

--- a/src/io/pipe.php
+++ b/src/io/pipe.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\IO;
 
-use namespace HH\Lib\{_Private\_IO, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{_Private\_IO};
 
 /** Create a pair of handles, where writes to the `WriteHandle` can be
  * read from the `ReadHandle`.
@@ -18,7 +19,7 @@ use namespace HH\Lib\{_Private\_IO, OS};
  * @see `Network\Socket`
  */
 function pipe(): (CloseableReadFDHandle, CloseableWriteFDHandle) {
-  list($r, $w) = \HH\Lib\OS\pipe();
+  list($r, $w) = \HH\Staging\OS\pipe();
   return tuple(
     new _IO\PipeReadHandle($r),
     new _IO\PipeWriteHandle($w),

--- a/src/io/stdio.php
+++ b/src/io/stdio.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\IO;
 
-use namespace HH\Lib\OS;
+use namespace HH\Staging\OS;
 use namespace HH\Lib\_Private\_IO;
 
 /** Return the output handle for the current request.

--- a/src/network/_Private/resolve_hostname.php
+++ b/src/network/_Private/resolve_hostname.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\_Private\_Network;
 
-use namespace HH\Lib\{Network, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{Network};
 use namespace HH\Lib\_Private\{_Network, _OS, _TCP};
 
 /** A poor alternative to OS\getaddrinfo, which doesn't exist yet. */

--- a/src/network/_Private/socket_accept_async.php
+++ b/src/network/_Private/socket_accept_async.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_Network;
 
-use namespace HH\Lib\OS;
+use namespace HH\Staging\OS;
 use namespace HH\Lib\_Private\_OS;
 /** Accept a socket connection, waiting if necessary */
 async function socket_accept_async(

--- a/src/network/_Private/socket_connect_async.php
+++ b/src/network/_Private/socket_connect_async.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_Network;
 
-use namespace HH\Lib\OS;
+use namespace HH\Staging\OS;
 use namespace HH\Lib\_Private\_OS;
 
 /** Asynchronously connect to a socket.

--- a/src/network/_Private/socket_create_bind_listen_async.php
+++ b/src/network/_Private/socket_create_bind_listen_async.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\_Private\_Network;
 
-use namespace HH\Lib\{Network, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{Network};
 use namespace HH\Lib\_Private\_OS;
 
 /** Create a server socket and start listening */

--- a/src/os/AddressFamily.php
+++ b/src/os/AddressFamily.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/Errno.php
+++ b/src/os/Errno.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/ErrnoException.php
+++ b/src/os/ErrnoException.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\C;
 use namespace HH\Lib\_Private\_OS;

--- a/src/os/FileDescriptor.php
+++ b/src/os/FileDescriptor.php
@@ -8,10 +8,7 @@
  *
  */
 
-namespace HH\Lib\IO;
+namespace HH\Staging\OS;
 
-use namespace HH\Staging\OS;
-
-interface FDHandle extends Handle {
-  public function getFileDescriptor(): OS\FileDescriptor;
-}
+// built in
+type FileDescriptor = \HH\Lib\OS\FileDescriptor;

--- a/src/os/HErrno.php
+++ b/src/os/HErrno.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 // hackfmt-ignore
 /** OS-level host error number constants from `netdb.h`.

--- a/src/os/HErrnoException.php
+++ b/src/os/HErrnoException.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\C;
 use namespace HH\Lib\_Private\_OS;

--- a/src/os/README.md
+++ b/src/os/README.md
@@ -1,4 +1,4 @@
-# `HH\Lib\OS`
+# `HH\Staging\OS`
 
 The namespace is intended to contain very low-level functions, primarily as a
 base layer for implementing higher-level libraries (e.g. `HH\Lib\IO`), and
@@ -15,7 +15,7 @@ this document over time.
 - Similar low-level functions that are portably found in libc, if there is a
   strong reason to use prefer them to POSIX functions (e.g. `mkostemps`)
 - Hack-specific functions that allow interoperation between `OS\` and other
-  key Hack functionality, e.g. `HH\Lib\OS\poll_async()`, allowing `await`ing
+  key Hack functionality, e.g. `HH\Staging\OS\poll_async()`, allowing `await`ing
   on `HH\Lib\FileDescriptor`s.
 
 For now, functions for use in HSL IO are high priority; it is expected that

--- a/src/os/SocketDomain.php
+++ b/src/os/SocketDomain.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/SocketType.php
+++ b/src/os/SocketType.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/_Private/Errno.php
+++ b/src/os/_Private/Errno.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\_Private\_OS;
 
-use namespace HH\Lib\{C, OS, Str};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{C, Str};
 
 <<__Memoize>>
 function get_throw_errno_impl(): (function(OS\Errno, string): noreturn) {

--- a/src/os/_Private/ErrnoExceptionWithMultipleErrnosTrait.php
+++ b/src/os/_Private/ErrnoExceptionWithMultipleErrnosTrait.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\_Private\_OS;
 
-use namespace HH\Lib\{C, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{C};
 
 trait ErrnoExceptionWithMultipleErrnosTrait {
   require extends OS\ErrnoException;

--- a/src/os/_Private/ErrnoExceptionWithSingleErrnoTrait.php
+++ b/src/os/_Private/ErrnoExceptionWithSingleErrnoTrait.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_OS;
 
-use namespace HH\Lib\OS;
+use namespace HH\Staging\OS;
 
 
 trait ErrnoExceptionWithSingleErrnoTrait {

--- a/src/os/_Private/HError.php
+++ b/src/os/_Private/HError.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_OS;
 
-use namespace HH\Lib\OS;
+use namespace HH\Staging\OS;
 
 // hackfmt-ignore
 /** OS-level host error number constants from `netdb.h`.

--- a/src/os/_Private/arg_assert.php
+++ b/src/os/_Private/arg_assert.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\_Private\_OS;
 
-use namespace HH\Lib\{Str, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{Str};
 
 /** Raises EINVAL if condition is false */
 function arg_assert(bool $condition, Str\SprintfFormatString $message, mixed ...$args): void {

--- a/src/os/_Private/constants.php
+++ b/src/os/_Private/constants.php
@@ -10,6 +10,6 @@
 
 namespace HH\Lib\_Private\_OS;
 
-use namespace HH\Lib\OS;
+use namespace HH\Staging\OS;
 
 const bool IS_MACOS = \PHP_OS === 'Darwin';

--- a/src/os/_Private/get_errno_names.php
+++ b/src/os/_Private/get_errno_names.php
@@ -9,7 +9,8 @@
  */
 
 namespace HH\Lib\_Private\_OS;
-use namespace HH\Lib\{Dict, Keyset, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{Dict, Keyset};
 
 <<__Memoize>>
 function get_errno_names(): dict<OS\Errno, keyset<string>> {

--- a/src/os/_Private/native_sockaddr_from_sockaddr.php
+++ b/src/os/_Private/native_sockaddr_from_sockaddr.php
@@ -9,7 +9,7 @@
  */
 
 namespace HH\Lib\_Private\_OS;
-use namespace HH\Lib\OS;
+use namespace HH\Staging\OS;
 
 function native_sockaddr_from_sockaddr(OS\sockaddr $sa): namespace\sockaddr {
   if ($sa is OS\sockaddr_un) {

--- a/src/os/_Private/sockaddr_from_native_sockaddr.php
+++ b/src/os/_Private/sockaddr_from_native_sockaddr.php
@@ -9,7 +9,7 @@
  */
 
 namespace HH\Lib\_Private\_OS;
-use namespace HH\Lib\OS;
+use namespace HH\Staging\OS;
 
 function sockaddr_from_native_sockaddr(namespace\sockaddr $sa): OS\sockaddr {
   if ($sa is namespace\sockaddr_un_pathname) {

--- a/src/os/_Private/wrap_impl.php
+++ b/src/os/_Private/wrap_impl.php
@@ -10,7 +10,7 @@
 
 namespace HH\Lib\_Private\_OS;
 
-use namespace HH\Lib\OS;
+use namespace HH\Staging\OS;
 
 function wrap_impl<T>((function(): T) $impl): T {
   try {

--- a/src/os/accept.php
+++ b/src/os/accept.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/bind.php
+++ b/src/os/bind.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/close.php
+++ b/src/os/close.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/connect.php
+++ b/src/os/connect.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/fcntl.php
+++ b/src/os/fcntl.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/flock.php
+++ b/src/os/flock.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/getpeername.php
+++ b/src/os/getpeername.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/getsockname.php
+++ b/src/os/getsockname.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/in6_addr.php
+++ b/src/os/in6_addr.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS {
+namespace HH\Staging\OS {
 
   /** The type of the network form of an INET6 (IPv6) address.
    *
@@ -19,7 +19,7 @@ namespace HH\Lib\OS {
 }
 
 namespace HH\Lib\_Private\_OS {
-  function string_as_in6_addr_UNSAFE(string $in): \HH\Lib\OS\in6_addr {
+  function string_as_in6_addr_UNSAFE(string $in): \HH\Staging\OS\in6_addr {
     return $in;
   }
 }

--- a/src/os/in_addr.php
+++ b/src/os/in_addr.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 /** The type of the network form of an INET (IPv4) address, in host byte order.
  *

--- a/src/os/inet_ntop.php
+++ b/src/os/inet_ntop.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\Str;
 use namespace HH\Lib\_Private\_OS;

--- a/src/os/inet_pton.php
+++ b/src/os/inet_pton.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\Str;
 use namespace HH\Lib\_Private\_OS;

--- a/src/os/isatty.php
+++ b/src/os/isatty.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/listen.php
+++ b/src/os/listen.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/lseek.php
+++ b/src/os/lseek.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/mkdtemp.php
+++ b/src/os/mkdtemp.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\Str;
 use namespace HH\Lib\_Private\_OS;

--- a/src/os/mkostemps.php
+++ b/src/os/mkostemps.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\Str;
 use namespace HH\Lib\_Private\_OS;

--- a/src/os/open.php
+++ b/src/os/open.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/pipe.php
+++ b/src/os/pipe.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/read.php
+++ b/src/os/read.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/sockaddr.php
+++ b/src/os/sockaddr.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/sockaddr_in.php
+++ b/src/os/sockaddr_in.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 /** Address of an INET (IPv4) socket.
  *

--- a/src/os/sockaddr_in6.php
+++ b/src/os/sockaddr_in6.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 /** Address of an INET6 (IPv6) socket.
  *

--- a/src/os/sockaddr_un.php
+++ b/src/os/sockaddr_un.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 /** Address of a UNIX-domain socket.
  *

--- a/src/os/socket.php
+++ b/src/os/socket.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/stdio.php
+++ b/src/os/stdio.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/ttyname.php
+++ b/src/os/ttyname.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/os/write.php
+++ b/src/os/write.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace HH\Lib\OS;
+namespace HH\Staging\OS;
 
 use namespace HH\Lib\_Private\_OS;
 

--- a/src/tcp/Server.php
+++ b/src/tcp/Server.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\TCP;
 
-use namespace HH\Lib\{OS, Network};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{Network};
 use namespace HH\Lib\_Private\{_Network, _OS, _TCP};
 
 final class Server implements Network\Server<CloseableSocket> {

--- a/src/tcp/_Private/CloseableTCPSocket.php
+++ b/src/tcp/_Private/CloseableTCPSocket.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\_Private\_TCP;
 
-use namespace HH\Lib\{IO, Network, OS, TCP};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO, Network, TCP};
 use namespace HH\Lib\_Private\{_IO, _Network};
 
 final class CloseableTCPSocket

--- a/src/tcp/connect.php
+++ b/src/tcp/connect.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\TCP;
 
-use namespace HH\Lib\{Network, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{Network};
 use namespace HH\Lib\_Private\{_Network, _OS, _TCP};
 
 /** Connect to a socket asynchronously, returning a non-disposable handle.

--- a/src/unix/Server.php
+++ b/src/unix/Server.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\Unix;
 
-use namespace HH\Lib\{Network, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{Network};
 use namespace HH\Lib\_Private\{_Network, _Unix};
 
 final class Server implements Network\Server<CloseableSocket> {

--- a/src/unix/_Private/CloseableSocket.php
+++ b/src/unix/_Private/CloseableSocket.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\_Private\_Unix;
 
-use namespace HH\Lib\{IO, Network, OS, Unix};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO, Network, Unix};
 use namespace HH\Lib\_Private\{_IO, _Network};
 
 final class CloseableSocket

--- a/src/unix/connect.php
+++ b/src/unix/connect.php
@@ -10,7 +10,8 @@
 
 namespace HH\Lib\Unix;
 
-use namespace HH\Lib\{Network, OS};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{Network};
 use namespace HH\Lib\_Private\{_Network, _Unix};
 
 /** Asynchronously connect to the specified unix socket. */

--- a/tests/file/FileTest.php
+++ b/tests/file/FileTest.php
@@ -8,7 +8,8 @@
  *
  */
 
-use namespace HH\Lib\{File, OS, PseudoRandom, Str};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{File, PseudoRandom, Str};
 
 use function Facebook\FBExpect\expect; // @oss-enable
 use type Facebook\HackTest\HackTest; // @oss-enable

--- a/tests/io/BufferedReaderTest.php
+++ b/tests/io/BufferedReaderTest.php
@@ -8,7 +8,8 @@
  *
  */
 
-use namespace HH\Lib\{IO, OS, Str, Vec};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO, Str, Vec};
 use namespace HH\Lib\_Private\_IO;
 
 use function Facebook\FBExpect\expect; // @oss-enable

--- a/tests/io/MemoryHandleTest.php
+++ b/tests/io/MemoryHandleTest.php
@@ -8,7 +8,8 @@
  *
  */
 
-use namespace HH\Lib\{IO, OS, Str};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO, Str};
 
 use function Facebook\FBExpect\expect; // @oss-enable
 use type Facebook\HackTest\HackTest; // @oss-enable

--- a/tests/io/PipeTest.php
+++ b/tests/io/PipeTest.php
@@ -8,7 +8,8 @@
  *
  */
 
-use namespace HH\Lib\{IO, OS, Str};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO, Str};
 
 use function Facebook\FBExpect\expect; // @oss-enable
 use type Facebook\HackTest\HackTest; // @oss-enable

--- a/tests/os/MkdtempTest.php
+++ b/tests/os/MkdtempTest.php
@@ -8,7 +8,8 @@
  *
  */
 
-use namespace HH\Lib\{IO, OS, Str};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO, Str};
 
 use function Facebook\FBExpect\expect; // @oss-enable
 use type Facebook\HackTest\HackTest; // @oss-enable

--- a/tests/tcp/HSLTCPTest.php
+++ b/tests/tcp/HSLTCPTest.php
@@ -9,7 +9,8 @@
  */
 
 use namespace HH\Lib\Vec;
-use namespace HH\Lib\{IO, Network, OS, Str, TCP};
+use namespace HH\Staging\OS;
+use namespace HH\Lib\{IO, Network, Str, TCP};
 
 use function Facebook\FBExpect\expect; // @oss-enable
 use type Facebook\HackTest\HackTest; // @oss-enable


### PR DESCRIPTION
Summary:

Within FB, we need to do a change like this to avoid namign conflicts
when we add the HSL to HHVM and the typechecker.

I've done this one first as it's the most complicated, as there is a
native type that is public, `HH\Lib\FileDescriptor` - as it's never
newed up directly, a type alias works fine.

```
- find src tests -type f | xargs gsed -i 's,HH\\Lib\\OS,HH\\Staging\\OS,g'
- find src tests -type f -name ‘*.php’ | xargs gawk -i inplace '{ if ($0 ~ /, OS[,}]/) { print "use namespace HH\\Staging\\OS;"; print gensub(/, OS([,}])/,"\\1", "g", $0)} else { print $0 }}'
- find src tests -type f -name ‘*.php’ | xargs gawk -i inplace '{ if ($0 ~ /{OS, /) { print "use namespace HH\\Staging\\OS;"; print gensub(/{OS, /,"{", "g", $0)} else { print $0 }}'
```

Finally, manually added the TypeDescriptor alias

Worked on this on a public checkout for faster dev cycle

Test plan:

hh_client, unit tests
