### PR TITLE
HSL Env: Introduction

### DIFF
--- a/src/env/_Private/GlobalEnvironment.php
+++ b/src/env/_Private/GlobalEnvironment.php
@@ -1,0 +1,33 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Env\_Private;
+
+use namespace HH;
+
+final abstract class GlobalEnvironment {
+  public static function getAll(): dict<string, string> {
+    $env = (HH\global_key_exists('_ENV') ? HH\global_get('_ENV') : dict[])
+      |> $$ as HH\KeyedTraversable<_, _>;
+
+    $result = dict[];
+    foreach ($env as $key => $value) {
+      if ($key is string && $value is string) {
+        $result[$key] = $value;
+      }
+    }
+
+    return $result;
+  }
+
+  public static function setAll(dict<string, string> $env): void {
+    HH\global_set('_ENV', $env);
+  }
+}

--- a/src/env/args.php
+++ b/src/env/args.php
@@ -1,0 +1,23 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Env;
+
+/**
+ * Returns the arguments which this program was started with (normally passed via the command line).
+ */
+function args()[globals]: vec<string> {
+    if (\HH\global_key_exists('argv')) {
+        /* HH_IGNORE_ERROR[4110] */
+        return vec(\HH\global_get('argv'));
+    }
+
+    return vec[];
+}

--- a/src/env/current_dir.php
+++ b/src/env/current_dir.php
@@ -1,0 +1,26 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Env;
+
+/**
+ * Returns the current working directory.
+ */
+function current_dir(): string {
+  /* HH_FIXME[2049] __PHPStdLib */
+  /* HH_FIXME[4107] __PHPStdLib */
+  $directory = \getcwd();
+  invariant(
+    $directory is string,
+    'Unable to retrieve current working directory.',
+  );
+
+  return $directory;
+}

--- a/src/env/get_var.php
+++ b/src/env/get_var.php
@@ -1,0 +1,29 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Env;
+
+use HH\Lib\Str;
+
+/**
+ * Fetches the environment variable $key from the current process.
+ */
+function get_var(string $key): ?string {
+  invariant(
+    !Str\is_empty($key) &&
+      !Str\contains($key, '=') &&
+      !Str\contains($key, "\0"),
+    'Invalid environment variable key provided.',
+  );
+
+  $variables = get_vars();
+
+  return $variables[$key] ?? null;
+}

--- a/src/env/get_vars.php
+++ b/src/env/get_vars.php
@@ -1,0 +1,18 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Env;
+
+/**
+ * Returns a dict of (variable, value) pairs of strings, for all the environment variables of the current process.
+ */
+function get_vars(): dict<string, string> {
+  return _Private\GlobalEnvironment::getAll();
+}

--- a/src/env/join_paths.php
+++ b/src/env/join_paths.php
@@ -1,0 +1,20 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Env;
+
+use HH\Lib\Str;
+
+/**
+ * Joins a collection of paths appropriately for the PATH environment variable.
+ */
+function join_paths(string ...$paths)[]: string {
+    return Str\join($paths, \PATH_SEPARATOR);
+}

--- a/src/env/remove_var.php
+++ b/src/env/remove_var.php
@@ -1,0 +1,30 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Env;
+
+use namespace HH\Lib\Str;
+
+/**
+ * Removes an environment variable from the environment of the currently running process.
+ *
+ * @throws If $key is empty, or contains an ASCII equals sign `=` or
+ *  the NUL character `\0`.
+ */
+function remove_var(string $key): void {
+    invariant(
+        !Str\is_empty($key) &&
+            !Str\contains($key, '=') &&
+            !Str\contains($key, "\0"),
+        'Invalid environment variable key provided.',
+    );
+
+    // TODO(azjezz): putenv($key), or unset($_ENV[$key])?
+}

--- a/src/env/set_current_dir.php
+++ b/src/env/set_current_dir.php
@@ -1,0 +1,18 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Env;
+
+/**
+ * Changes the current working directory to the specified path.
+ */
+function set_current_dir(string $directory): void {
+    invariant(\chdir($directory), 'Unable to change directory');
+}

--- a/src/env/set_var.php
+++ b/src/env/set_var.php
@@ -1,0 +1,39 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Env;
+
+use HH\Lib\Str;
+
+/**
+ * Sets the environment variable $key to the value $value for the currently running process.
+ *
+ * @throws If $key is empty, contains an ASCII equals sign `=`,
+ *  the NUL character `\0`, or when the $value contains
+ *  the NUL character.
+ */
+function set_var(string $key, string $value): void {
+    invariant(
+        !Str\is_empty($key) &&
+            !Str\contains($key, '=') &&
+            !Str\contains($key, "\0"),
+        'Invalid environment variable key provided.',
+    );
+
+    invariant(
+        !Str\contains($value, "\0"),
+        'Invalid environment variable value provided.',
+    );
+
+    $env = _Private\GlobalEnvironment::getAll();
+    $env[$key] = $value;
+
+    _Private\GlobalEnvironment::setAll($env);
+}

--- a/src/env/split_paths.php
+++ b/src/env/split_paths.php
@@ -1,0 +1,20 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Env;
+
+use HH\Lib\Str;
+
+/**
+ * Parses input according to platform conventions for the PATH environment variable.
+ */
+function split_paths(string $path)[]: vec<string> {
+    return Str\split($path, \PATH_SEPARATOR);
+}

--- a/src/env/temp_dir.php
+++ b/src/env/temp_dir.php
@@ -1,0 +1,27 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Env;
+
+/**
+ * Returns the value of the "TMPDIR" environment variable if it is set, otherwise it returns /tmp.
+ *
+ * @note On windows, we can't count on the environment variables "TEMP" or "TMP",
+ *      and so must make the Win32 API call to get the default directory for temporary files.
+ *
+ * @note The return value of this function can be overridden using the sys_temp_dir ini directive.
+ *
+ * @see https://www.php.net/manual/en/function.sys-get-temp-dir.php
+ */
+function temp_dir(): string {
+  /* HH_FIXME[2049] __PHPStdLib */
+  /* HH_FIXME[4107] __PHPStdLib */
+  return \sys_get_temp_dir();
+}


### PR DESCRIPTION
👋 

I wanted to bootstrap the work on `HH\Lib\Env`, so this is PR is more of a "meta PR" to keep the discussion going.

This API is borrowed as-is from [PSL](https://github.com/azjezz/psl), and it was initially inspired by the [`std::env` crate from Rust](https://doc.rust-lang.org/std/env/index.html).

The component contains common functions that are needed for day-to-day operations especially when writing CLI applications, such as dealing with process environment variables, retrieving `args`, and retrieving the current directory/script.

I'm not sure if this is the API we want in Hack, but so far, it has served it's purpose really well in both PHP and Rust.

> Note: this PR missing the `Env\current_exec()` implementation, as it's a bit messy in PHP ( see [`current_exec.php`](https://github.com/azjezz/psl/blob/1.8.x/src/Psl/Env/current_exec.php) ), so I'm wondering if there's a better way to do that here.


