### PR TITLE
Match visibility in super class

### DIFF
--- a/src/datetime/DateTime/Zoned.php
+++ b/src/datetime/DateTime/Zoned.php
@@ -215,7 +215,7 @@ final class Zoned extends DateTime implements Instant {
   }
 
   <<__Override>>
-  public function getISOWeekNumberImpl(): int {
+  protected function getISOWeekNumberImpl(): int {
     return (int)$this->format('%V');
   }
 


### PR DESCRIPTION
The Unzoned arm of the type hierarchy and the super class are protected.
This appears to be public by mistake.