### PR TITLE
Remove final for a private function

### DIFF
--- a/src/datetime/_Private/Timestamp.php
+++ b/src/datetime/_Private/Timestamp.php
@@ -18,7 +18,7 @@ use type HH\Lib\Experimental\Time;
 <<__ConsistentConstruct>>
 abstract class Timestamp extends Comparable {
 
-  final private function __construct(
+  private function __construct(
     private int $seconds,
     private int $nanoseconds,
   ) {}


### PR DESCRIPTION
This change suppress the compilation error after updating Hack to 4.136+